### PR TITLE
remove old behavior on requestobject on request refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+coverage

--- a/models/requestObject.js
+++ b/models/requestObject.js
@@ -59,7 +59,7 @@ function construct (object, additionalData, protocol) {
     this.data.body = object.body;
   }
   else if (object.query !== undefined) {
-    this.data.body = object;
+    this.data.body = {query: object.query};
   }
   else {
     this.data.body = additionalData.body || additionalData;

--- a/models/requestObject.js
+++ b/models/requestObject.js
@@ -59,10 +59,7 @@ function construct (object, additionalData, protocol) {
     this.data.body = object.body;
   }
   else if (object.query !== undefined) {
-    this.data = object;
-  }
-  else if (additionalData.query !== undefined) {
-    this.data = additionalData;
+    this.data.body = object;
   }
   else {
     this.data.body = additionalData.body || additionalData;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzzle-common-objects",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "dependencies": {
     "lodash": "^4.13.1",
     "node-uuid": "^1.4.7",

--- a/test/requestObject.test.js
+++ b/test/requestObject.test.js
@@ -72,9 +72,9 @@ describe('Test: requestObject', function () {
 
     request.query = query;
     delete request.body;
-    requestObject = new RequestObject(request, { query: {bar: 'foo' }}, protocol);
+    requestObject = new RequestObject(request, { query: {bar: 'foo'} }, protocol);
 
-    should(requestObject.data).match(request);
+    should(requestObject.data).match({body: {query}});
   });
 
   it('should replace the entire data structure by the additional data if it contains a query member', function () {
@@ -85,7 +85,7 @@ describe('Test: requestObject', function () {
     delete request.body;
     requestObject = new RequestObject(request, additionalData, protocol);
 
-    should(requestObject.data).match(additionalData);
+    should(requestObject.data).match({body: additionalData});
   });
 
   it('should initialize the data.body structure with the additional data argument if none of the previous cases matches', function () {


### PR DESCRIPTION
Changed the way that requestObject is builded.

seen with @ballinette 
We need to organize a workshop to speak about refactoring some things on all inputs in kuzzle (there is a lot of divergences)
