### PR TITLE
Optimizations & Response headers [High priority!!]

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This constructor is used to transform an [API request](http://kuzzle.io/api-refe
 |------|------|---------|----------------------------------|
 | `context` | `RequestContext` | [RequestContext](#modelsrequestcontext) object | Request connection context |
 | `error` | `KuzzleError` | `null` | Request error, if any |
-| `id` | string | Request unique identifier |
+| `id` | string | Auto-generated UUID | Request unique identifier |
 | `input` | `RequestInput` | [RequestInput](#modelsrequestinput) object | Request's parameters |
 | `result` | *(varies)* | `null` | Request result, if any |
 | `status` | `integer` | `102` | HTTP status code |

--- a/README.md
+++ b/README.md
@@ -229,18 +229,26 @@ Other attributes may be defined and will automatically be added to the `args` ob
 
 ### Attributes
 
+**Read-only**
+
+The following attributes can be set after the object has been built, but once set, they cannot be changed:
+
 | Name | Type | Default | Description                      |
 |------|------|---------|----------------------------------|
 | `action` | `string` | `null` | Controller's action to execute |
+| `controller` | `string` | `null` | Kuzzle's controller to invoke |
+
+**Writable**
+
+| Name | Type | Default | Description                      |
+|------|------|---------|----------------------------------|
 | `args` | `object` | *(empty)* | Contains specific request arguments |
 | `body` | `object` | `null` | Request's body (for instance, the content of a document) |
-| `controller` | `string` | `null` | Kuzzle's controller to invoke |
 | `metadata` | `object` | `null` | Request [metadata](http://kuzzle.io/api-reference/?websocket#sending-metadata) |
 | `resource._id` | `string` | `null` | Document unique identifier |
 | `resource.collection` | `string` | `null` | Data collection |
 | `resource.index` | `string` | `null` | Data index |
 | `jwt` | `string` | `null` | JWT Authentication token |
-
 
 ## `errors.KuzzleError`
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This constructor is used to transform an [API request](http://kuzzle.io/api-refe
 |------|------|---------|----------------------------------|
 | `context` | `RequestContext` | [RequestContext](#modelsrequestcontext) object | Request connection context |
 | `error` | `KuzzleError` | `null` | Request error, if any |
-| `id` | string | Auto-generated UUID | Request unique identifier |
+| `id` | `string` | Auto-generated UUID | Request unique identifier |
 | `input` | `RequestInput` | [RequestInput](#modelsrequestinput) object | Request's parameters |
 | `result` | *(varies)* | `null` | Request result, if any |
 | `status` | `integer` | `102` | HTTP status code |

--- a/lib/errors/kuzzleError.js
+++ b/lib/errors/kuzzleError.js
@@ -22,11 +22,7 @@ inherits(KuzzleError, Error);
 KuzzleError.prototype.name = 'KuzzleError';
 
 KuzzleError.prototype.toJSON = function () {
-  return {
-    status: this.status,
-    message: this.message,
-    stack: this.stack
-  };
+  return this;
 };
 
 /**

--- a/lib/models/requestContext.js
+++ b/lib/models/requestContext.js
@@ -2,13 +2,6 @@
 
 const assert = require('../utils/assertType');
 
-// Private variables
-let
-  _connectionId = new WeakMap(),
-  _protocol = new WeakMap(),
-  _token = new WeakMap(),
-  _user = new WeakMap();
-
 /**
  * @class
  * @param {object} [options]
@@ -30,31 +23,13 @@ let
  * @type {object}
  */
 class RequestContext {
-  constructor(options) {
-    options = options || {};
+  constructor(_options) {
+    let options = _options || {};
 
-    Object.defineProperties(this, {
-      connectionId: {
-        get: function () { return _connectionId.get(this); },
-        set: function (str) { _connectionId.set(this, assert.assertString('connectionId', str));},
-        enumerable: true
-      },
-      protocol: {
-        get: function () { return _protocol.get(this); },
-        set: function (str) { _protocol.set(this, assert.assertString('protocol', str)); },
-        enumerable: true
-      },
-      token: {
-        get: function () { return _token.get(this); },
-        set: function (obj) { _token.set(this, assert.assertObject('token', obj)); },
-        enumerable: true
-      },
-      user: {
-        get: function () { return _user.get(this); },
-        set: function (obj) { _user.set(this, assert.assertObject('user', obj)); },
-        enumerable: true
-      }
-    });
+    this._connectionId = null;
+    this._protocol = null;
+    this._token = null;
+    this._user = null;
 
     Object.seal(this);
 
@@ -62,6 +37,45 @@ class RequestContext {
     this.protocol = options.protocol;
     this.token = options.token;
     this.user = options.user;
+  }
+
+  toJSON() {
+    return {
+      connectionId: this._connectionId,
+      protocol: this._protocol
+    };
+  }
+
+  get connectionId () {
+    return this._connectionId;
+  }
+
+  set connectionId (str) {
+    this._connectionId = assert.assertString('connectionId', str);
+  }
+
+  get protocol () {
+    return this._protocol;
+  }
+
+  set protocol (str) {
+    this._protocol = assert.assertString('protocol', str);
+  }
+
+  get token () {
+    return this._token;
+  }
+
+  set token (obj) {
+    this._token = assert.assertObject('token', obj);
+  }
+
+  get user () {
+    return this._user;
+  }
+
+  set user (obj) {
+    this._user = assert.assertObject('user', obj);
   }
 }
 

--- a/lib/models/requestContext.js
+++ b/lib/models/requestContext.js
@@ -40,10 +40,15 @@ class RequestContext {
   }
 
   toJSON() {
-    return {
-      connectionId: this._connectionId,
-      protocol: this._protocol
-    };
+    let json = {};
+
+    Object.keys(this)
+      .filter(key => key[0] === '_')
+      .forEach(key => {
+        json[key.substring(1)] = this[key];
+      });
+
+    return json;
   }
 
   get connectionId () {

--- a/lib/models/requestContext.js
+++ b/lib/models/requestContext.js
@@ -2,6 +2,13 @@
 
 const assert = require('../utils/assertType');
 
+// private properties
+const
+  _connectionId = Symbol(),
+  _protocol = Symbol(),
+  _token = Symbol(),
+  _user = Symbol();
+
 /**
  * @class
  * @param {object} [options]
@@ -26,10 +33,11 @@ class RequestContext {
   constructor(_options) {
     let options = _options || {};
 
-    this._connectionId = null;
-    this._protocol = null;
-    this._token = null;
-    this._user = null;
+
+    this[_connectionId] = null;
+    this[_protocol] = null;
+    this[_token] = null;
+    this[_user] = null;
 
     Object.seal(this);
 
@@ -40,15 +48,12 @@ class RequestContext {
   }
 
   toJSON() {
-    let json = {};
-
-    Object.keys(this)
-      .filter(key => key[0] === '_')
-      .forEach(key => {
-        json[key.substring(1)] = this[key];
-      });
-
-    return json;
+    return {
+      connectionId: this[_connectionId],
+      protocol: this[_protocol],
+      user: this[_user],
+      token: this[_token]
+    };
   }
 
   /**
@@ -56,7 +61,7 @@ class RequestContext {
    * @returns {null|string}
    */
   get connectionId () {
-    return this._connectionId;
+    return this[_connectionId];
   }
 
   /**
@@ -64,7 +69,7 @@ class RequestContext {
    * @param {null|string} str - new context connectionId
    */
   set connectionId (str) {
-    this._connectionId = assert.assertString('connectionId', str);
+    this[_connectionId] = assert.assertString('connectionId', str);
   }
 
   /**
@@ -72,7 +77,7 @@ class RequestContext {
    * @returns {null|string}
    */
   get protocol () {
-    return this._protocol;
+    return this[_protocol];
   }
 
   /**
@@ -80,7 +85,7 @@ class RequestContext {
    * @param {null|string} str - new context protocol
    */
   set protocol (str) {
-    this._protocol = assert.assertString('protocol', str);
+    this[_protocol] = assert.assertString('protocol', str);
   }
 
   /**
@@ -88,7 +93,7 @@ class RequestContext {
    * @returns {null|object}
    */
   get token () {
-    return this._token;
+    return this[_token];
   }
 
   /**
@@ -96,7 +101,7 @@ class RequestContext {
    * @param {null|object} obj - new context token
    */
   set token (obj) {
-    this._token = assert.assertObject('token', obj);
+    this[_token] = assert.assertObject('token', obj);
   }
 
   /**
@@ -104,7 +109,7 @@ class RequestContext {
    * @returns {null|object}
    */
   get user () {
-    return this._user;
+    return this[_user];
   }
 
   /**
@@ -112,7 +117,7 @@ class RequestContext {
    * @param {null|object} obj - new context user
    */
   set user (obj) {
-    this._user = assert.assertObject('user', obj);
+    this[_user] = assert.assertObject('user', obj);
   }
 }
 

--- a/lib/models/requestContext.js
+++ b/lib/models/requestContext.js
@@ -51,34 +51,66 @@ class RequestContext {
     return json;
   }
 
+  /**
+   * Context connectionId getter
+   * @returns {null|string}
+   */
   get connectionId () {
     return this._connectionId;
   }
 
+  /**
+   * Context connectionId setter
+   * @param {null|string} str - new context connectionId
+   */
   set connectionId (str) {
     this._connectionId = assert.assertString('connectionId', str);
   }
 
+  /**
+   * Context protocol getter
+   * @returns {null|string}
+   */
   get protocol () {
     return this._protocol;
   }
 
+  /**
+   * Context protocol setter
+   * @param {null|string} str - new context protocol
+   */
   set protocol (str) {
     this._protocol = assert.assertString('protocol', str);
   }
 
+  /**
+   * Context token getter
+   * @returns {null|object}
+   */
   get token () {
     return this._token;
   }
 
+  /**
+   * Context token setter
+   * @param {null|object} obj - new context token
+   */
   set token (obj) {
     this._token = assert.assertObject('token', obj);
   }
 
+  /**
+   * Context user getter
+   * @returns {null|object}
+   */
   get user () {
     return this._user;
   }
 
+  /**
+   * Context user setter
+   * @param {null|object} obj - new context user
+   */
   set user (obj) {
     this._user = assert.assertObject('user', obj);
   }

--- a/lib/models/requestInput.js
+++ b/lib/models/requestInput.js
@@ -6,14 +6,14 @@ const
 
 // private properties
 const
-  __id = Symbol(),
-  _index = Symbol(),
-  _collection = Symbol(),
-  _jwt = Symbol(),
-  _metadata = Symbol(),
-  _body = Symbol(),
-  _controller = Symbol(),
-  _action = Symbol();
+  __id = Symbol.for('_id'),
+  _index = Symbol.for('index'),
+  _collection = Symbol.for('collection'),
+  _jwt = Symbol.for('jwt'),
+  _metadata = Symbol.for('metadata'),
+  _body = Symbol.for('body'),
+  _controller = Symbol.for('controller'),
+  _action = Symbol.for('action');
 
 class Resource {
   constructor() {
@@ -119,8 +119,11 @@ class RequestInput {
 
     Object.seal(this);
 
+    const symbols = Array.prototype.concat(Object.getOwnPropertySymbols(this), Object.getOwnPropertySymbols(this.resource))
+      .map(sym => Symbol.keyFor(sym));
+
     Object.keys(data).forEach(k => {
-      if (!this[`_${k}`] && !this.resource[`_${k}`]) {
+      if (symbols.indexOf(k) === -1) {
         this.args[k] = data[k];
       }
     });

--- a/lib/models/requestInput.js
+++ b/lib/models/requestInput.js
@@ -124,18 +124,34 @@ class RequestInput {
     this.resource._id = data._id;
   }
 
+  /**
+   * Request jwt getter
+   * @returns {null|string}
+   */
   get jwt () {
     return this._jwt;
   }
 
+  /**
+   * Request jwt setter
+   * @param {null|string} str - new jwt
+   */
   set jwt (str) {
     this._jwt = assert.assertString('jwt', str);
   }
 
+  /**
+   * Request controller getter
+   * @returns {null|string}
+   */
   get controller () {
     return this._controller;
   }
 
+  /**
+   * Request controller setter
+   * @param {null|string} str - new request controller
+   */
   set controller (str) {
     // can only be set once
     if (!this._controller) {
@@ -143,10 +159,18 @@ class RequestInput {
     }
   }
 
+  /**
+   * Request action getter
+   * @returns {null|string}
+   */
   get action () {
     return this._action;
   }
 
+  /**
+   * Request action setter
+   * @param {null|string} str - new request action
+   */
   set action (str) {
     // can only be set once
     if (!this._action) {
@@ -154,18 +178,34 @@ class RequestInput {
     }
   }
 
+  /**
+   * Request body getter
+   * @returns {null|object}
+   */
   get body () {
     return this._body;
   }
 
+  /**
+   * Request body setter
+   * @param {null|object} obj - new request body
+   */
   set body (obj) {
     this._body = assert.assertObject('body', obj);
   }
 
+  /**
+   * Request metadata getter
+   * @returns {null|object}
+   */
   get metadata () {
     return this._metadata;
   }
 
+  /**
+   * Request metadata setter
+   * @param {null|object} obj - new request metadata
+   */
   set metadata (obj) {
     this._metadata = assert.assertObject('metadata', obj);
   }

--- a/lib/models/requestInput.js
+++ b/lib/models/requestInput.js
@@ -4,37 +4,48 @@ const
   InternalError = require('../errors/internalError'),
   assert = require('../utils/assertType');
 
+// private properties
+const
+  __id = Symbol(),
+  _index = Symbol(),
+  _collection = Symbol(),
+  _jwt = Symbol(),
+  _metadata = Symbol(),
+  _body = Symbol(),
+  _controller = Symbol(),
+  _action = Symbol();
+
 class Resource {
   constructor() {
-    this.__id = null;
-    this._index = null;
-    this._collection = null;
+    this[__id] = null;
+    this[_index] = null;
+    this[_collection] = null;
 
     Object.seal(this);
   }
 
   get _id () {
-    return this.__id;
+    return this[__id];
   }
 
   set _id (str) {
-    this.__id = assert.assertString('_id', str);
+    this[__id] = assert.assertString('_id', str);
   }
 
   get index () {
-    return this._index;
+    return this[_index];
   }
 
   set index (str) {
-    this._index = assert.assertString('index', str);
+    this[_index] = assert.assertString('index', str);
   }
 
   get collection () {
-    return this._collection;
+    return this[_collection];
   }
 
   set collection (str) {
-    this._collection = assert.assertString('collection', str);
+    this[_collection] = assert.assertString('collection', str);
   }
 }
 
@@ -97,11 +108,11 @@ class RequestInput {
       throw new InternalError('Input request data must be a non-null object');
     }
 
-    this._jwt = null;
-    this._metadata = null;
-    this._body = null;
-    this._controller = null;
-    this._action = null;
+    this[_jwt] = null;
+    this[_metadata] = null;
+    this[_body] = null;
+    this[_controller] = null;
+    this[_action] = null;
 
     this.args = {};
     this.resource = new Resource();
@@ -129,7 +140,7 @@ class RequestInput {
    * @returns {null|string}
    */
   get jwt () {
-    return this._jwt;
+    return this[_jwt];
   }
 
   /**
@@ -137,7 +148,7 @@ class RequestInput {
    * @param {null|string} str - new jwt
    */
   set jwt (str) {
-    this._jwt = assert.assertString('jwt', str);
+    this[_jwt] = assert.assertString('jwt', str);
   }
 
   /**
@@ -145,7 +156,7 @@ class RequestInput {
    * @returns {null|string}
    */
   get controller () {
-    return this._controller;
+    return this[_controller];
   }
 
   /**
@@ -154,8 +165,8 @@ class RequestInput {
    */
   set controller (str) {
     // can only be set once
-    if (!this._controller) {
-      this._controller = assert.assertString('controller', str);
+    if (!this[_controller]) {
+      this[_controller] = assert.assertString('controller', str);
     }
   }
 
@@ -164,7 +175,7 @@ class RequestInput {
    * @returns {null|string}
    */
   get action () {
-    return this._action;
+    return this[_action];
   }
 
   /**
@@ -173,8 +184,8 @@ class RequestInput {
    */
   set action (str) {
     // can only be set once
-    if (!this._action) {
-      this._action = assert.assertString('action', str);
+    if (!this[_action]) {
+      this[_action] = assert.assertString('action', str);
     }
   }
 
@@ -183,7 +194,7 @@ class RequestInput {
    * @returns {null|object}
    */
   get body () {
-    return this._body;
+    return this[_body];
   }
 
   /**
@@ -191,7 +202,7 @@ class RequestInput {
    * @param {null|object} obj - new request body
    */
   set body (obj) {
-    this._body = assert.assertObject('body', obj);
+    this[_body] = assert.assertObject('body', obj);
   }
 
   /**
@@ -199,7 +210,7 @@ class RequestInput {
    * @returns {null|object}
    */
   get metadata () {
-    return this._metadata;
+    return this[_metadata];
   }
 
   /**
@@ -207,7 +218,7 @@ class RequestInput {
    * @param {null|object} obj - new request metadata
    */
   set metadata (obj) {
-    this._metadata = assert.assertObject('metadata', obj);
+    this[_metadata] = assert.assertObject('metadata', obj);
   }
 }
 

--- a/lib/models/requestInput.js
+++ b/lib/models/requestInput.js
@@ -4,16 +4,39 @@ const
   InternalError = require('../errors/internalError'),
   assert = require('../utils/assertType');
 
-// Private variables
-let
-  _jwt = new WeakMap(),
-  _metadata = new WeakMap(),
-  _body = new WeakMap(),
-  _controller = new WeakMap(),
-  _action = new WeakMap(),
-  _resourceIndex = new WeakMap(),
-  _resourceCollection = new WeakMap(),
-  _resourceId = new WeakMap();
+class Resource {
+  constructor() {
+    this.__id = null;
+    this._index = null;
+    this._collection = null;
+
+    Object.seal(this);
+  }
+
+  get _id () {
+    return this.__id;
+  }
+
+  set _id (str) {
+    this.__id = assert.assertString('_id', str);
+  }
+
+  get index () {
+    return this._index;
+  }
+
+  set index (str) {
+    this._index = assert.assertString('index', str);
+  }
+
+  get collection () {
+    return this._collection;
+  }
+
+  set collection (str) {
+    this._collection = assert.assertString('collection', str);
+  }
+}
 
 /**
  * Builds a Kuzzle normalized request input object
@@ -74,75 +97,19 @@ class RequestInput {
       throw new InternalError('Input request data must be a non-null object');
     }
 
-    Object.defineProperties(this, /** @memberOf RequestInput# */ {
-      jwt: {
-        enumerable: true,
-        get: function () { return _jwt.get(this); },
-        set: function (str) { _jwt.set(this, assert.assertString('jwt', str)); }
-      },
-      controller: {
-        enumerable: true,
-        get: function () { return _controller.get(this); },
-        set: function (str) {
-          // can only be set once
-          if (!_controller.get(this)) {
-            _controller.set(this, assert.assertString('controller', str));
-          }
-        }
-      },
-      action: {
-        enumerable: true,
-        get: function () { return _action.get(this); },
-        set: function (str) {
-          // can only be set once
-          if (!_action.get(this)) {
-            _action.set(this, assert.assertString('action', str));
-          }
-        }
-      },
-      resource: {
-        value: {},
-        enumerable: true
-      },
-      args: {
-        value: {},
-        enumerable: true
-      },
-      body: {
-        enumerable: true,
-        get: function () { return _body.get(this); },
-        set: function (obj) { _body.set(this, assert.assertObject('body', obj)); }
-      },
-      metadata: {
-        enumerable: true,
-        get: function () { return _metadata.get(this); },
-        set: function (obj) { _metadata.set(this, assert.assertObject('metadata', obj)); }
-      }
-    });
+    this._jwt = null;
+    this._metadata = null;
+    this._body = null;
+    this._controller = null;
+    this._action = null;
 
-    Object.defineProperties(this.resource, {
-      index: {
-        get: function () { return _resourceIndex.get(this); },
-        set: function(str) { _resourceIndex.set(this, assert.assertString('index', str)); },
-        enumerable: true
-      },
-      collection: {
-        get: function () { return _resourceCollection.get(this); },
-        set: function(str) { _resourceCollection.set(this, assert.assertString('collection', str)); },
-        enumerable: true
-      },
-      _id: {
-        get: function () { return _resourceId.get(this); },
-        set: function(str) { _resourceId.set(this, assert.assertString('_id', str)); },
-        enumerable: true
-      }
-    });
+    this.args = {};
+    this.resource = new Resource();
 
-    Object.seal(this.resource);
     Object.seal(this);
 
     Object.keys(data).forEach(k => {
-      if (!this.hasOwnProperty(k) && !this.resource.hasOwnProperty(k)) {
+      if (!this[`_${k}`] && !this.resource[`_${k}`]) {
         this.args[k] = data[k];
       }
     });
@@ -155,6 +122,52 @@ class RequestInput {
     this.resource.index = data.index;
     this.resource.collection = data.collection;
     this.resource._id = data._id;
+  }
+
+  get jwt () {
+    return this._jwt;
+  }
+
+  set jwt (str) {
+    this._jwt = assert.assertString('jwt', str);
+  }
+
+  get controller () {
+    return this._controller;
+  }
+
+  set controller (str) {
+    // can only be set once
+    if (!this._controller) {
+      this._controller = assert.assertString('controller', str);
+    }
+  }
+
+  get action () {
+    return this._action;
+  }
+
+  set action (str) {
+    // can only be set once
+    if (!this._action) {
+      this._action = assert.assertString('action', str);
+    }
+  }
+
+  get body () {
+    return this._body;
+  }
+
+  set body (obj) {
+    this._body = assert.assertObject('body', obj);
+  }
+
+  get metadata () {
+    return this._metadata;
+  }
+
+  set metadata (obj) {
+    this._metadata = assert.assertObject('metadata', obj);
   }
 }
 

--- a/lib/models/requestResponse.js
+++ b/lib/models/requestResponse.js
@@ -1,0 +1,245 @@
+'use strict';
+
+const
+  assert = require('../utils/assertType');
+
+const
+  _request = Symbol('request'),
+  _headers = Symbol('headers');
+
+/**
+ * Kuzzle normalized response
+ *
+ * @class
+ * @param {Request} request
+ *
+ */
+class RequestResponse {
+  constructor (request) {
+
+    this[_request] = request;
+    this[_headers] = this[_request][Symbol.for('request.response.headers')];
+
+    Object.seal(this);
+  }
+
+  /**
+   * Get the parent request status
+   * @returns {number}
+   */
+  get status () {
+    return this[_request].status;
+  }
+
+  /**
+   * Set the parent request status
+   * @param {number} s
+   */
+  set status (s) {
+    return this[_request].status = s;
+  }
+
+  /**
+   * Get the parent request error
+   * @returns {KuzzleError}
+   */
+  get error () {
+    return this[_request].error;
+  }
+
+  /**
+   * Set the parent request error
+   * @param {KuzzleError} e
+   */
+  set error (e) {
+    return this[_request].setError(e);
+  }
+
+  /**
+   * Get the parent request id
+   * @returns {string|*|String}
+   */
+  get requestId () {
+    return this[_request].id;
+  }
+
+  /**
+   * Get the parent request controller
+   * @returns {string}
+   */
+  get controller () {
+    return this[_request].input.controller;
+  }
+
+  /**
+   * Get the parent request action
+   * @returns {string}
+   */
+  get action () {
+    return this[_request].input.action;
+  }
+
+  /**
+   * Get the parent request collection
+   * @returns {string}
+   */
+  get collection () {
+    return this[_request].input.resource.collection;
+  }
+
+  /**
+   * Get the parent request index
+   * @returns {string}
+   */
+  get index () {
+    return this[_request].input.resource.index;
+  }
+
+  /**
+   * Get the parent request metadata
+   * @returns {Object}
+   */
+  get metadata () {
+    return this[_request].input.metadata;
+  }
+
+  /**
+   * Get the response headers - reference to private parent request property
+   * @returns {*}
+   */
+  get headers () {
+    return this[_headers];
+  }
+
+  /**
+   * Get the parent request result
+   * @returns {*|null|*|Object}
+   */
+  get result () {
+    return this[_request].result;
+  }
+
+  /**
+   * Set the parent request result
+   * @param {*} r
+   */
+  set result (r) {
+    return this[_request].setResult(r);
+  }
+
+  /**
+   * Get the header value for {name} (case-insensitive)
+   * @public
+   * @param {string} name
+   */
+  getHeader (name) {
+    let value;
+
+    Object.keys(this[_headers])
+      .filter(key => key.toLowerCase() === name.toLowerCase())
+      .some(key => {
+        value = this[_headers][key];
+      });
+
+    return value;
+  }
+
+  /**
+   * Delete the header matching {name} (case-insensitive=
+   * @param {string} name
+   */
+  removeHeader (name) {
+    Object.keys(this[_headers])
+      .filter(key => key.toLowerCase() === name.toLowerCase())
+      .forEach(key => delete this[_headers][key]);
+  }
+
+  /**
+   * Set a new array. Behaves the same as [Node HTTP response.setHeader method](https://nodejs.org/api/http.html#http_response_setheader_name_value)
+   * @param {string} name
+   * @param {string} value
+   */
+  setHeader (name, value) {
+    assert.assertString('header name', name);
+    assert.assertString('header value', value);
+
+    switch(name.toLowerCase()) {
+      case 'age':
+      case 'authorization':
+      case 'content-length':
+      case 'content-type':
+      case 'etag':
+      case 'expires':
+      case 'from':
+      case 'host':
+      case 'if-modified-since':
+      case 'if-unmodified-since':
+      case 'last-modified, location':
+      case 'max-forwards':
+      case 'proxy-authorization':
+      case 'referer':
+      case 'retry-after':
+      case 'user-agent':
+        Object.keys(this[_headers])
+          .filter(key => key.toLowerCase() === name.toLowerCase())
+          .forEach(key => delete this[_headers][key]);
+        this[_headers][name] = value;
+        break;
+      case 'set-cookie':
+        if (!this[_headers]['set-cookie']) {
+          this[_headers]['set-cookie'] = [value];
+        }
+        else {
+          this[_headers]['set-cookie'].push(value);
+        }
+        break;
+      default:
+        if (!Object.keys(this[_headers])
+          .filter(key => key.toLowerCase() === name.toLowerCase())
+          .some(key => {
+            this[_headers][key] += ', ' + value;
+            return true;
+          })
+        ){
+          this[_headers][name] = value;
+        }
+    }
+
+  }
+
+  /**
+   * **Add** new multiple headers
+   * @param {object} headers
+   */
+  setHeaders (headers) {
+    let hdrs = assert.assertUniTypeObject('headers', headers, 'string');
+
+    if (hdrs === null) {
+      return;
+    }
+
+    Object.keys(hdrs)
+      .forEach(name => this.setHeader(name, hdrs[name]));
+  }
+
+  /**
+   * Serialize the response. Exposes the prototype getters values
+   * @returns {object}
+   */
+  toJSON () {
+    return Object.assign({}, {
+      status: this.status,
+      error: this.error,
+      requestId: this.requestId,
+      controller: this.controller,
+      action: this.action,
+      collection: this.collection,
+      index: this.index,
+      metadata: this.metadata,
+      headers: this.headers,
+      result: this.result
+    });
+  }
+}
+
+module.exports = RequestResponse;

--- a/lib/models/requestResponse.js
+++ b/lib/models/requestResponse.js
@@ -133,15 +133,12 @@ class RequestResponse {
    * @param {string} name
    */
   getHeader (name) {
-    let value;
+    let key = Object.keys(this[_headers])
+      .filter(key => key.toLowerCase() === name.toLowerCase())[0];
 
-    Object.keys(this[_headers])
-      .filter(key => key.toLowerCase() === name.toLowerCase())
-      .some(key => {
-        value = this[_headers][key];
-      });
-
-    return value;
+    if (key) {
+      return this[_headers][key];
+    }
   }
 
   /**

--- a/lib/request.js
+++ b/lib/request.js
@@ -58,6 +58,7 @@ class Request {
     this._status = 102;
     this._input = new RequestInput(data);
     this._error = null;
+    this._responseHeaders = [];
     this._result = null;
     this._context = new RequestContext(options);
 
@@ -81,7 +82,7 @@ class Request {
        * been specified.
        */
       if (options.result) {
-        this.setResult(options.result);
+        this.setResult(options.result, options.status, options.responseHeaders);
       }
 
       if (options.error) {
@@ -130,6 +131,7 @@ class Request {
       collection: this._input.resource.collection,
       index: this._input.resource.index,
       metadata: this._input.metadata,
+      headers: this._responseHeaders,
       result: this._result
     };
   }
@@ -157,12 +159,21 @@ class Request {
    * @param {Number} [status] - defaults to 200
    * @memberOf Request
    */
-  setResult(result, status) {
+  setResult(result, status, headers) {
     if (result instanceof Error) {
       throw new InternalError('cannot set an error as a request\'s response');
     }
 
     this.status = status || 200;
+
+    if (headers) {
+      if (!Array.isArray(headers)) {
+        throw new InternalError('response headers must a be an array');
+      }
+
+      this._responseHeaders = headers;
+    }
+
     this._result = result;
   }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -5,6 +5,7 @@ const
   assert = require('./utils/assertType'),
   RequestContext = require('./models/requestContext'),
   RequestInput = require('./models/requestInput'),
+  RequestResponse = require('./models/requestResponse'),
   KuzzleError = require('./errors/kuzzleError'),
   InternalError = require('./errors/internalError');
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -8,14 +8,6 @@ const
   KuzzleError = require('./errors/kuzzleError'),
   InternalError = require('./errors/internalError');
 
-// Private variables
-let
-  _status = new WeakMap(),
-  _input = new WeakMap(),
-  _context = new WeakMap(),
-  _error = new WeakMap(),
-  _result = new WeakMap();
-
 /**
  * Builds a Kuzzle normalized request object
  *
@@ -63,59 +55,14 @@ let
  */
 class Request {
   constructor(data, options) {
-    Object.defineProperties(this,
-    {
-      id: {
-        value: data.requestId ? assert.assertString('requestId', data.requestId) : uuid.v4(),
-        enumerable: true,
-        writable: true
-      },
-      timestamp: {
-        value: Date.now(),
-        enumerable: true
-      },
-      status: {
-        set: function (i) { _status.set(this, assert.assertInteger('status', i)); },
-        get: function () { return _status.get(this); },
-        enumerable: true
-      },
-      error: {
-        get: function () { return _error.get(this); },
-        enumerable: true
-      },
-      input: {
-        get: function () { return _input.get(this); },
-        enumerable: true
-      },
-      result: {
-        get: function () { return _result.get(this); },
-        enumerable: true
-      },
-      context: {
-        get: function () { return _context.get(this); },
-        enumerable: true
-      },
-      response: {
-        get: function () {
-          return {
-            status: this.status,
-            error: this.error,
-            requestId: this.id,
-            controller: this.input.controller,
-            action: this.input.action,
-            collection: this.input.resource.collection,
-            index: this.input.resource.index,
-            metadata: this.input.metadata,
-            result: this.result
-          };
-        },
-        enumerable: true
-      }
-    });
+    this._status = 102;
+    this._input = new RequestInput(data);
+    this._error = null;
+    this._result = null;
+    this._context = new RequestContext(options);
 
-    this.status = 102;
-    _error.set(this, null);
-    _result.set(this, null);
+    this.id = data.requestId ? assert.assertString('requestId', data.requestId) : uuid.v4();
+    this.timestamp = data.timestamp || Date.now();
 
     // handling provided options
     if (options !== undefined && options !== null) {
@@ -146,10 +93,45 @@ class Request {
       }
     }
 
-    _input.set(this, new RequestInput(data));
-    _context.set(this, new RequestContext(options));
-
     Object.seal(this);
+  }
+
+  get status () {
+    return this._status;
+  }
+
+  set status (i)  {
+    this._status = assert.assertInteger('status', i);
+  }
+
+  get input () {
+    return this._input;
+  }
+
+  get context () {
+    return this._context;
+  }
+
+  get error () {
+    return this._error;
+  }
+
+  get result () {
+    return this._result;
+  }
+
+  get response () {
+    return {
+      status: this._status,
+      error: this._error,
+      requestId: this.id,
+      controller: this._input.controller,
+      action: this._input.action,
+      collection: this._input.resource.collection,
+      index: this._input.resource.index,
+      metadata: this._input.metadata,
+      result: this._result
+    };
   }
 
   /**
@@ -164,8 +146,8 @@ class Request {
       throw new InternalError('cannot set non-error object as a request\'s error');
     }
 
-    _error.set(this, error instanceof KuzzleError ? error : new InternalError(error));
-    this.status = this.error.status;
+    this._error = error instanceof KuzzleError ? error : new InternalError(error);
+    this.status = this._error.status;
   }
 
   /**
@@ -181,7 +163,7 @@ class Request {
     }
 
     this.status = status || 200;
-    _result.set(this, result);
+    this._result = result;
   }
 
   /**
@@ -195,28 +177,27 @@ class Request {
   serialize() {
     let serialized = {
       data: {
+        timestamp: this.timestamp,
         requestId: this.id,
-        jwt: this.input.jwt,
-        metadata: this.input.metadata,
-        body: this.input.body,
-        controller: this.input.controller,
-        action: this.input.action,
-        index: this.input.resource.index,
-        collection: this.input.resource.collection,
-        _id: this.input.resource._id
+        jwt: this._input.jwt,
+        metadata: this._input.metadata,
+        body: this._input.body,
+        controller: this._input.controller,
+        action: this._input.action,
+        index: this._input.resource.index,
+        collection: this._input.resource.collection,
+        _id: this._input.resource._id,
       },
       options: {
-        connectionId: this.context.connectionId,
-        protocol: this.context.protocol,
-        result: this.result,
-        error: this.error,
-        status: this.status
+        connectionId: this._context.connectionId,
+        protocol: this._context.protocol,
+        result: this._result,
+        error: this._error,
+        status: this._status
       }
     };
 
-    Object.keys(this.input.args).forEach(k => {
-      serialized.data[k] = this.input.args[k];
-    });
+    Object.assign(serialized.data, this._input.args);
 
     return serialized;
   }

--- a/lib/request.js
+++ b/lib/request.js
@@ -17,7 +17,6 @@ const
   _responseHeaders = Symbol.for('request.response.headers'),
   _result = Symbol(),
   _context = Symbol(),
-  _id = Symbol(),
   _timestamp = Symbol(),
   _response = Symbol();
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -5,6 +5,7 @@ const
   assert = require('./utils/assertType'),
   RequestContext = require('./models/requestContext'),
   RequestInput = require('./models/requestInput'),
+  RequestResponse = require('./models/requestResponse'),
   KuzzleError = require('./errors/kuzzleError'),
   InternalError = require('./errors/internalError');
 
@@ -13,11 +14,12 @@ const
   _status = Symbol(),
   _input = Symbol(),
   _error = Symbol(),
-  _responseHeaders = Symbol(),
+  _responseHeaders = Symbol.for('request.response.headers'),
   _result = Symbol(),
   _context = Symbol(),
   _id = Symbol(),
-  _timestamp = Symbol();
+  _timestamp = Symbol(),
+  _response = Symbol();
 
 /**
  * Builds a Kuzzle normalized request object
@@ -54,7 +56,7 @@ const
  */
 /**
  * @name Request#response
- * @type {object}
+ * @type {RequestResponse}
  */
 /**
  * @name Request#result
@@ -69,9 +71,10 @@ class Request {
     this[_status] = 102;
     this[_input] = new RequestInput(data);
     this[_error] = null;
-    this[_responseHeaders] = [];
+    this[_responseHeaders] = {};
     this[_result] = null;
     this[_context] = new RequestContext(options);
+    this[_response] = null;
 
     this[_id] = data.requestId ? assert.assertString('requestId', data.requestId) : uuid.v4();
     this[_timestamp] = data.timestamp || Date.now();
@@ -177,18 +180,10 @@ class Request {
    * @returns {{status: (number|*), error: (null|*), requestId: string, controller: string, action: string, collection: string, index: string, metadata: Object, headers: (Array|*), result: (null|*|Object)}}
    */
   get response () {
-    return {
-      status: this[_status],
-      error: this[_error],
-      requestId: this[_id],
-      controller: this[_input].controller,
-      action: this[_input].action,
-      collection: this[_input].resource.collection,
-      index: this[_input].resource.index,
-      metadata: this[_input].metadata,
-      headers: this[_responseHeaders],
-      result: this[_result]
-    };
+    if (this[_response] === null) {
+      this[_response] = new RequestResponse(this);
+    }
+    return this[_response];
   }
 
   /**
@@ -212,7 +207,7 @@ class Request {
    *
    * @param {Object} result - result content
    * @param {Number} [status] - defaults to 200
-   * @param {Array} [headers] - defaults to null
+   * @param {Object} [headers] - defaults to null
    * @memberOf Request
    */
   setResult(result, status, headers) {
@@ -223,11 +218,7 @@ class Request {
     this.status = status || 200;
 
     if (headers) {
-      if (!Array.isArray(headers)) {
-        throw new InternalError('response headers must be an array');
-      }
-
-      this[_responseHeaders] = headers;
+      this.response.setHeaders(headers);
     }
 
     this[_result] = result;

--- a/lib/request.js
+++ b/lib/request.js
@@ -97,30 +97,58 @@ class Request {
     Object.seal(this);
   }
 
+  /**
+   * Request status getter
+   * @returns {number}
+   */
   get status () {
     return this._status;
   }
 
+  /**
+   * Request status setter
+   * @param {number} i - new request status
+   */
   set status (i)  {
     this._status = assert.assertInteger('status', i);
   }
 
+  /**
+   * Request input getter
+   * @returns {RequestInput}
+   */
   get input () {
     return this._input;
   }
 
+  /**
+   * Request context getter
+   * @returns {RequestContext}
+   */
   get context () {
     return this._context;
   }
 
+  /**
+   * Request error getter
+   * @returns {null|KuzzleError}
+   */
   get error () {
     return this._error;
   }
 
+  /**
+   * Request result getter
+   * @returns {null|*}
+   */
   get result () {
     return this._result;
   }
 
+  /**
+   * Request response getter
+   * @returns {{status: (number|*), error: (null|*), requestId: string, controller: string, action: string, collection: string, index: string, metadata: Object, headers: (Array|*), result: (null|*|Object)}}
+   */
   get response () {
     return {
       status: this._status,
@@ -157,6 +185,7 @@ class Request {
    *
    * @param {Object} result - result content
    * @param {Number} [status] - defaults to 200
+   * @param {Array} [headers] - defaults to null
    * @memberOf Request
    */
   setResult(result, status, headers) {
@@ -168,7 +197,7 @@ class Request {
 
     if (headers) {
       if (!Array.isArray(headers)) {
-        throw new InternalError('response headers must a be an array');
+        throw new InternalError('response headers must be an array');
       }
 
       this._responseHeaders = headers;

--- a/lib/request.js
+++ b/lib/request.js
@@ -8,6 +8,17 @@ const
   KuzzleError = require('./errors/kuzzleError'),
   InternalError = require('./errors/internalError');
 
+// private properties
+const
+  _status = Symbol(),
+  _input = Symbol(),
+  _error = Symbol(),
+  _responseHeaders = Symbol(),
+  _result = Symbol(),
+  _context = Symbol(),
+  _id = Symbol(),
+  _timestamp = Symbol();
+
 /**
  * Builds a Kuzzle normalized request object
  *
@@ -55,15 +66,15 @@ const
  */
 class Request {
   constructor(data, options) {
-    this._status = 102;
-    this._input = new RequestInput(data);
-    this._error = null;
-    this._responseHeaders = [];
-    this._result = null;
-    this._context = new RequestContext(options);
+    this[_status] = 102;
+    this[_input] = new RequestInput(data);
+    this[_error] = null;
+    this[_responseHeaders] = [];
+    this[_result] = null;
+    this[_context] = new RequestContext(options);
 
-    this.id = data.requestId ? assert.assertString('requestId', data.requestId) : uuid.v4();
-    this.timestamp = data.timestamp || Date.now();
+    this[_id] = data.requestId ? assert.assertString('requestId', data.requestId) : uuid.v4();
+    this[_timestamp] = data.timestamp || Date.now();
 
     // handling provided options
     if (options !== undefined && options !== null) {
@@ -98,11 +109,27 @@ class Request {
   }
 
   /**
+   * Request id getter
+   * @returns {string}
+   */
+  get id () {
+    return this[_id];
+  }
+
+  /**
+   * Request timestamp getter
+   * @returns {number}
+   */
+  get timestamp () {
+    return this[_timestamp];
+  }
+
+  /**
    * Request status getter
    * @returns {number}
    */
   get status () {
-    return this._status;
+    return this[_status];
   }
 
   /**
@@ -110,7 +137,7 @@ class Request {
    * @param {number} i - new request status
    */
   set status (i)  {
-    this._status = assert.assertInteger('status', i);
+    this[_status] = assert.assertInteger('status', i);
   }
 
   /**
@@ -118,7 +145,7 @@ class Request {
    * @returns {RequestInput}
    */
   get input () {
-    return this._input;
+    return this[_input];
   }
 
   /**
@@ -126,7 +153,7 @@ class Request {
    * @returns {RequestContext}
    */
   get context () {
-    return this._context;
+    return this[_context];
   }
 
   /**
@@ -134,7 +161,7 @@ class Request {
    * @returns {null|KuzzleError}
    */
   get error () {
-    return this._error;
+    return this[_error];
   }
 
   /**
@@ -142,7 +169,7 @@ class Request {
    * @returns {null|*}
    */
   get result () {
-    return this._result;
+    return this[_result];
   }
 
   /**
@@ -151,16 +178,16 @@ class Request {
    */
   get response () {
     return {
-      status: this._status,
-      error: this._error,
-      requestId: this.id,
-      controller: this._input.controller,
-      action: this._input.action,
-      collection: this._input.resource.collection,
-      index: this._input.resource.index,
-      metadata: this._input.metadata,
-      headers: this._responseHeaders,
-      result: this._result
+      status: this[_status],
+      error: this[_error],
+      requestId: this[_id],
+      controller: this[_input].controller,
+      action: this[_input].action,
+      collection: this[_input].resource.collection,
+      index: this[_input].resource.index,
+      metadata: this[_input].metadata,
+      headers: this[_responseHeaders],
+      result: this[_result]
     };
   }
 
@@ -176,8 +203,8 @@ class Request {
       throw new InternalError('cannot set non-error object as a request\'s error');
     }
 
-    this._error = error instanceof KuzzleError ? error : new InternalError(error);
-    this.status = this._error.status;
+    this[_error] = error instanceof KuzzleError ? error : new InternalError(error);
+    this.status = this[_error].status;
   }
 
   /**
@@ -200,10 +227,10 @@ class Request {
         throw new InternalError('response headers must be an array');
       }
 
-      this._responseHeaders = headers;
+      this[_responseHeaders] = headers;
     }
 
-    this._result = result;
+    this[_result] = result;
   }
 
   /**
@@ -217,27 +244,27 @@ class Request {
   serialize() {
     let serialized = {
       data: {
-        timestamp: this.timestamp,
-        requestId: this.id,
-        jwt: this._input.jwt,
-        metadata: this._input.metadata,
-        body: this._input.body,
-        controller: this._input.controller,
-        action: this._input.action,
-        index: this._input.resource.index,
-        collection: this._input.resource.collection,
-        _id: this._input.resource._id,
+        timestamp: this[_timestamp],
+        requestId: this[_id],
+        jwt: this[_input].jwt,
+        metadata: this[_input].metadata,
+        body: this[_input].body,
+        controller: this[_input].controller,
+        action: this[_input].action,
+        index: this[_input].resource.index,
+        collection: this[_input].resource.collection,
+        _id: this[_input].resource._id,
       },
       options: {
-        connectionId: this._context.connectionId,
-        protocol: this._context.protocol,
-        result: this._result,
-        error: this._error,
-        status: this._status
+        connectionId: this[_context].connectionId,
+        protocol: this[_context].protocol,
+        result: this[_result],
+        error: this[_error],
+        status: this[_status]
       }
     };
 
-    Object.assign(serialized.data, this._input.args);
+    Object.assign(serialized.data, this[_input].args);
 
     return serialized;
   }

--- a/lib/utils/assertType.js
+++ b/lib/utils/assertType.js
@@ -23,6 +23,50 @@ function assertObject(attr, data) {
   return data;
 }
 
+/**
+ * Throws if the provided object is not an object or if it contains heterogeaous typed properties.
+ * Returns the unmodified data if validated.
+ *
+ * @throws {ParseError}
+ * @param {string} attr - tested attribute name
+ * @param {*} data
+ * @param {string} [type] - expected type for data properties
+ * @returns {object|null}
+ */
+function assertUniTypeObject(attr, data, type) {
+  data = assertObject(attr, data);
+
+  if (data === null) {
+    return null;
+  }
+
+  Object.keys(data).forEach(key => {
+    if (type === undefined) {
+      type = typeof data[key];
+    }
+    type = type.toLowerCase();
+
+    let msg = `Attribute ${attr} must be of type "object" and have all its properties of type ${type}.`
+      + `\nExpected "${attr}.${key}" to be of type "${type}", but go "${typeof data[key]}".`;
+
+    switch(type) {
+      case 'array':
+        if (!Array.isArray(data[key])) {
+          throw new ParseError(msg);
+        }
+        break;
+      default:
+        if (typeof data[key] !== type) {
+          throw new ParseError(msg);
+        }
+        break;
+    }
+
+  });
+
+  return data;
+}
+
 
 /**
  * Throws if the provided data is not a string
@@ -62,6 +106,7 @@ function assertInteger(attr, data) {
   return data;
 }
 
-module.exports.assertObject = assertObject;
-module.exports.assertString = assertString;
-module.exports.assertInteger = assertInteger;
+exports.assertObject = assertObject;
+exports.assertUniTypeObject = assertUniTypeObject;
+exports.assertString = assertString;
+exports.assertInteger = assertInteger;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Common objects shared to various Kuzzle components and plugins",
   "main": "./index.js",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "dependencies": {
     "uuid": "^3.0.0"
   },

--- a/test/models/requestContext.test.js
+++ b/test/models/requestContext.test.js
@@ -5,14 +5,19 @@ const
   RequestContext = require.main.require('lib/models/requestContext');
 
 describe('#RequestContext', () => {
-  it('should initialize itself with provided options', () => {
-    let context = new RequestContext({
-      connectionId: 'connectionId',
-      protocol: 'protocol',
-      token: {token: 'token'},
-      user: {user: 'user'}
-    });
+  const args = {
+    connectionId: 'connectionId',
+    protocol: 'protocol',
+    token: {token: 'token'},
+    user: {user: 'user'}
+  };
+  let context;
 
+  beforeEach(() => {
+    context = new RequestContext(args);
+  });
+
+  it('should initialize itself with provided options', () => {
     should(context.connectionId).eql('connectionId');
     should(context.protocol).eql('protocol');
     should(context.token).match({token: 'token'});
@@ -35,5 +40,10 @@ describe('#RequestContext', () => {
       should(function () { new RequestContext({[k]: 132}); }).throw(`Attribute ${k} must be of type "object"`);
       should(function () { new RequestContext({[k]: true}); }).throw(`Attribute ${k} must be of type "object"`);
     });
+  });
+
+  it('should serialize properly', () => {
+    should(context.toJSON())
+      .match(args);
   });
 });

--- a/test/models/requestContext.test.js
+++ b/test/models/requestContext.test.js
@@ -5,19 +5,6 @@ const
   RequestContext = require.main.require('lib/models/requestContext');
 
 describe('#RequestContext', () => {
-  let rqc;
-
-  beforeEach(() => {
-    rqc = new RequestContext();
-  });
-
-  it('should build a well-formed object', () => {
-    should(rqc).have.enumerable('connectionId');
-    should(rqc).have.enumerable('protocol');
-    should(rqc).have.enumerable('token');
-    should(rqc).have.enumerable('user');
-  });
-
   it('should initialize itself with provided options', () => {
     let context = new RequestContext({
       connectionId: 'connectionId',

--- a/test/models/requestResponse.test.js
+++ b/test/models/requestResponse.test.js
@@ -1,0 +1,210 @@
+'use strict';
+
+const
+  should = require('should'),
+  ParseError = require('../../lib/errors/parseError'),
+  Request = require('../../lib/request'),
+  RequestResponse = require('../../lib/models/requestResponse');
+
+describe('#RequestResponse', () => {
+  let req;
+
+  beforeEach(() => {
+    req = new Request({
+      index: 'index',
+      collection: 'collection',
+      controller: 'controller',
+      action: 'action'
+    });
+  });
+
+  describe('#constructor', () => {
+    it('should populate a valid response object', () => {
+      let response = new RequestResponse(req);
+
+      should(response.status).be.exactly(req.status);
+      should(response.error).be.exactly(req.error);
+      should(response.requestId).be.exactly(req.id);
+      should(response.controller).be.exactly(req.input.controller);
+      should(response.action).be.exactly(req.input.action);
+      should(response.collection).be.exactly(req.input.resource.collection);
+      should(response.index).be.exactly(req.input.resource.index);
+      should(response.metadata).be.exactly(req.input.metadata);
+      should(response.headers).be.exactly(req[Symbol.for('request.response.headers')]);
+      should(response.result).be.exactly(req.result);
+    });
+
+    it('should throw if we try to extend the response', () => {
+      let response = new RequestResponse(req);
+
+      should(() => { response.foo = 'bar'; }).throw(TypeError);
+    });
+  });
+
+  describe('#properties', () => {
+    it('should set the request status', () => {
+      const response = new RequestResponse(req);
+
+      response.status = 666;
+      should(req.status).be.exactly(666);
+    });
+
+    it('should set the request error', () => {
+      const
+        error = new ParseError('test'),
+        response = new RequestResponse(req);
+
+      response.error = error;
+      should(req.error).be.exactly(error);
+      should(req.status).be.exactly(error.status);
+    });
+
+    it('should set the request result', () => {
+      const
+        result = {foo: 'bar'},
+        response = new RequestResponse(req);
+
+      response.result = result;
+      should(req.result).be.exactly(result);
+    });
+  });
+
+  describe('headers', () => {
+    let response;
+
+    beforeEach(() => {
+      response = new RequestResponse(req);
+    });
+
+    it('should set headers', () => {
+      response.setHeader('X-Foo', 'Bar');
+      response.setHeader('X-Bar', 'Baz');
+
+      should(response.headers).match({
+        'X-Foo': 'Bar',
+        'X-Bar': 'Baz'
+      });
+
+      // set-cookie is a special key stored as an array
+      response.setHeader('Set-Cookie', 'test');
+      should(response.headers['set-cookie'])
+        .be.an.Array()
+        .have.length(1);
+      should(response.headers['set-cookie'][0])
+        .be.exactly('test');
+
+      response.setHeader('Set-Cookie', 'test2');
+      should(response.headers['set-cookie'][1])
+        .be.exactly('test2');
+
+      // special headers cannot be duplicated
+      [
+        'age',
+        'authorization',
+        'content-length',
+        'content-type',
+        'etag',
+        'expires',
+        'from',
+        'host',
+        'if-modified-since',
+        'if-unmodified-since',
+        'last-modified, location',
+        'max-forwards',
+        'proxy-authorization',
+        'referer',
+        'retry-after',
+        'user-agent'
+      ].forEach(name => {
+        response.setHeader(name, 'foobar');
+        response.setHeader(name, 'foobar');
+        should(response.headers[name])
+          .be.exactly('foobar');
+      });
+
+      // regular headers value are coma separated
+      response.setHeader('X-Baz', 'Foo');
+      response.setHeader('x-bAZ', 'Bar');
+
+      should(response.headers['X-Baz'])
+        .be.exactly('Foo, Bar');
+
+
+      // setHeaders adds received headers to current ones
+      response.setHeaders({
+        test: 'test',
+        banana: '42'
+      });
+
+      should(response.headers)
+        .have.property('X-Foo');
+      should(response.headers.test)
+        .be.exactly('test');
+      should(response.headers.banana)
+        .be.exactly('42');
+
+      // setHeaders does nothing if null is given
+      response.setHeaders(null);
+
+      // removeHeader
+      response.removeHeader('X-Foo');
+      should(response.headers)
+        .not.have.property('X-Foo');
+
+      // getHeader should be case-insensitive
+      should(response.getHeader('x-bAr'))
+        .be.exactly('Baz');
+    });
+
+    it('should throw if setHeader is called with non-string parameters', () => {
+      [
+        {},
+        1.42,
+        true,
+        []
+      ].forEach(param => {
+        should(() => response.setHeader(param, 'test')).throw(ParseError);
+        should(() => response.setHeader('test', param)).throw(ParseError);
+      });
+    });
+
+    it('should throw if setHeaders is called with an object containing non-string properties', () => {
+      [
+        {},
+        1.42,
+        true,
+        []
+      ].forEach(param => {
+        should(() => {
+          response.setHeaders({
+            foo: 'bar',
+            baz: param
+          });
+        }).throw(ParseError);
+      });
+    });
+  });
+
+  describe('toJSON', () => {
+    it('should return a valid JSON object', () => {
+      let response = new RequestResponse(req);
+
+      response.setHeader('x-foo', 'bar');
+
+      should(Object.keys(response.toJSON()))
+        .be.eql([
+          'status',
+          'error',
+          'requestId',
+          'controller',
+          'action',
+          'collection',
+          'index',
+          'metadata',
+          'headers',
+          'result'
+        ]);
+    });
+  });
+
+});

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -114,21 +114,20 @@ describe('#Request', () => {
     should(function () { rq.setResult('foobar', 123.45); }).throw('Attribute status must be an integer');
   });
 
-  it('should throw if trying to set some non-array headers', () => {
-    should(() => { rq.setResult('foobar', undefined, 42); }).throw('response headers must be an array');
-    should(() => { rq.setResult('foobar', undefined, {}); }).throw('response headers must be an array');
-    should(() => { rq.setResult('foobar', undefined, 'bar'); }).throw('response headers must be an array');
-    should(() => { rq.setResult('foobar', undefined, true); }).throw('response headers must be an array');
-
+  it('should throw if trying to set some non-object headers', () => {
+    should(() => { rq.setResult('foobar', undefined, 42); }).throw('Attribute headers must be of type "object"');
+    should(() => { rq.setResult('foobar', undefined, { a: true }); }).throw('Attribute headers must be of type "object" and have all its properties of type string.\nExpected "headers.a" to be of type "string", but go "boolean".');
+    should(() => { rq.setResult('foobar', undefined, 'bar'); }).throw('Attribute headers must be of type "object"');
+    should(() => { rq.setResult('foobar', undefined, true); }).throw('Attribute headers must be of type "object"');
   });
 
   it('should build a well-formed response', () => {
     let
       result = {foo: 'bar'},
-      responseHeaders = [
-        'X-Foo: bar',
-        'X-Bar: baz'
-      ],
+      responseHeaders = {
+        'X-Foo': 'bar',
+        'X-Bar': 'baz'
+      },
       error = new InternalError('foobar'),
       data = {
         index: 'idx',
@@ -156,7 +155,7 @@ describe('#Request', () => {
     should(response.collection).eql(data.collection);
     should(response.index).eql(data.index);
     should(response.metadata).match(data.metadata);
-    should(response.headers).be.exactly(responseHeaders);
+    should(response.headers).match(responseHeaders);
     should(response.result).be.exactly(result);
   });
 
@@ -165,6 +164,7 @@ describe('#Request', () => {
       result = {foo: 'bar'},
       error = new InternalError('foobar'),
       data = {
+        timestamp: 'timestamp',
         index: 'idx',
         collection: 'collection',
         controller: 'controller',
@@ -183,6 +183,8 @@ describe('#Request', () => {
 
     serialized = request.serialize();
 
-    should((new Request(serialized.data, serialized.options)).response).match(request.response);
+    let newRequest = new Request(serialized.data, serialized.options);
+    should(newRequest).match(request.response);
+    should(newRequest.timestamp).be.eql('timestamp');
   });
 });

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -115,10 +115,10 @@ describe('#Request', () => {
   });
 
   it('should throw if trying to set some non-array headers', () => {
-    should(() => { rq.setResult('foobar', undefined, 42) }).throw('response headers must a be an array');
-    should(() => { rq.setResult('foobar', undefined, {}) }).throw('response headers must a be an array');
-    should(() => { rq.setResult('foobar', undefined, 'bar') }).throw('response headers must a be an array');
-    should(() => { rq.setResult('foobar', undefined, true) }).throw('response headers must a be an array');
+    should(() => { rq.setResult('foobar', undefined, 42); }).throw('response headers must a be an array');
+    should(() => { rq.setResult('foobar', undefined, {}); }).throw('response headers must a be an array');
+    should(() => { rq.setResult('foobar', undefined, 'bar'); }).throw('response headers must a be an array');
+    should(() => { rq.setResult('foobar', undefined, true); }).throw('response headers must a be an array');
 
   });
 

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -15,14 +15,6 @@ describe('#Request', () => {
     rq = new Request({});
   });
 
-  it('should have a writable id property', () => {
-    should(rq).have.propertyWithDescriptor('id', {enumerable: true, writable: true, configurable: false});
-  });
-
-  it('should have a non-writable timestamp property', () => {
-    should(rq).have.propertyWithDescriptor('timestamp', {enumerable: true, writable: false, configurable: false});
-  });
-
   it('should defaults other properties correctly', () => {
     should(rq.status).eql(102);
     should(rq.context).be.instanceOf(RequestContext);

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -115,10 +115,10 @@ describe('#Request', () => {
   });
 
   it('should throw if trying to set some non-array headers', () => {
-    should(() => { rq.setResult('foobar', undefined, 42); }).throw('response headers must a be an array');
-    should(() => { rq.setResult('foobar', undefined, {}); }).throw('response headers must a be an array');
-    should(() => { rq.setResult('foobar', undefined, 'bar'); }).throw('response headers must a be an array');
-    should(() => { rq.setResult('foobar', undefined, true); }).throw('response headers must a be an array');
+    should(() => { rq.setResult('foobar', undefined, 42); }).throw('response headers must be an array');
+    should(() => { rq.setResult('foobar', undefined, {}); }).throw('response headers must be an array');
+    should(() => { rq.setResult('foobar', undefined, 'bar'); }).throw('response headers must be an array');
+    should(() => { rq.setResult('foobar', undefined, true); }).throw('response headers must be an array');
 
   });
 

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -67,6 +67,8 @@ describe('#Request', () => {
 
     should(rq.error).be.exactly(foo);
     should(rq.status).eql(666);
+
+    should(rq.error.toJSON()).be.exactly(foo);
   });
 
   it('should wrap a plain Error object into an InternalError one', () => {
@@ -112,9 +114,21 @@ describe('#Request', () => {
     should(function () { rq.setResult('foobar', 123.45); }).throw('Attribute status must be an integer');
   });
 
+  it('should throw if trying to set some non-array headers', () => {
+    should(() => { rq.setResult('foobar', undefined, 42) }).throw('response headers must a be an array');
+    should(() => { rq.setResult('foobar', undefined, {}) }).throw('response headers must a be an array');
+    should(() => { rq.setResult('foobar', undefined, 'bar') }).throw('response headers must a be an array');
+    should(() => { rq.setResult('foobar', undefined, true) }).throw('response headers must a be an array');
+
+  });
+
   it('should build a well-formed response', () => {
     let
       result = {foo: 'bar'},
+      responseHeaders = [
+        'X-Foo: bar',
+        'X-Bar: baz'
+      ],
       error = new InternalError('foobar'),
       data = {
         index: 'idx',
@@ -129,7 +143,7 @@ describe('#Request', () => {
       request = new Request(data),
       response;
 
-    request.setResult(result);
+    request.setResult(result, 201, responseHeaders);
     request.setError(error);
 
     response = request.response;
@@ -142,6 +156,7 @@ describe('#Request', () => {
     should(response.collection).eql(data.collection);
     should(response.index).eql(data.index);
     should(response.metadata).match(data.metadata);
+    should(response.headers).be.exactly(responseHeaders);
     should(response.result).be.exactly(result);
   });
 

--- a/test/utils/assertType.test.js
+++ b/test/utils/assertType.test.js
@@ -1,0 +1,30 @@
+const
+  should = require('should'),
+  assert = require('../../lib/utils/assertType'),
+  ParseError = require('../../lib/errors/parseError');
+
+describe('#assertType', () => {
+  describe('#assertUnitTypeObject', () => {
+    it('should infer the type from the first property', () => {
+      should(() => {
+        assert.assertUniTypeObject('test', {
+          foo: ['bar'],
+          baz: true
+        });
+
+      }).throw(ParseError);
+    });
+
+    it('should detect object of arrays', () => {
+      const data = {
+        a: [1],
+        b: [2, 4],
+        c: 42,
+
+      };
+
+      should(() => assert.assertUniTypeObject('test', data, 'array'))
+        .throw(ParseError);
+    });
+  });
+});


### PR DESCRIPTION
# Optimizations

It turns out using weakMaps to simulate some private properties causes some performance penalty and some memory leak.
=> Removed in favor of plain simple _ prefixed internal vars

# Response headers

This functionality is totally out of the scope of the previous item but was included there as it was quite urgent and would have caused conflict with the previous development.
The Request.response object has been added a `headers` Array property. The idea is that

* For HTTP protocol,  the proxy will treat them as HTTP headers (to be developed)
* Plugins can then add some custom headers like setting some cookies or defining some Content-cache directives.