### PR TITLE
kuzzle-#586: dynamic http options

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Common objects shared to various Kuzzle components and plugins.
     - [Methods](#methods)
       - [`serialize()`](#serialize)
       - [`setError(error)`](#seterrorerror)
-      - [`setResult(result, [status = 200])`](#setresultresult-status--200)
+      - [`setResult(result, [options = null])`](#setresultresult-options--null)
     - [Example](#example)
   - [`RequestResponse`](#requestresponse)
     - [Attributes](#attributes-1)
@@ -40,7 +40,7 @@ Common objects shared to various Kuzzle components and plugins.
   - [`errors.ServiceUnavailableError`](#errorsserviceunavailableerror)
   - [`errors.SizeLimitError`](#errorssizelimiterror)
   - [`errors.UnauthorizedError`](#errorsunauthorizederror)
-  
+
 ## `Request`
 
 This constructor is used to transform an [API request](http://kuzzle.io/api-reference/?websocket#common-attributes) into a standardized Kuzzle request.
@@ -62,7 +62,7 @@ This constructor is used to transform an [API request](http://kuzzle.io/api-refe
 | `error` | `KuzzleError` or `Error` | Invokes [setError](#seterrorerror) at initialization |
 | `protocol` | `string` | Passed to [RequestContext](#modelsrequestcontext) constructor |
 | `requestId` | `string` | Initializes the `id` property |
-| `result` | *(varies)* | Invokes [setResult](#setresultresult-status--200) at initialization |
+| `result` | *(varies)* | Invokes [setResult](#setresultresult-options--null) at initialization |
 | `status` | `integer` | HTTP error code |
 | `token` | `object` | Passed to [RequestContext](#modelsrequestcontext) constructor |
 | `user` | `object` | Passed to [RequestContext](#modelsrequestcontext) constructor |
@@ -123,16 +123,24 @@ If a `KuzzleError` is provided, the request's status attribute is set to the err
 
 Otherwise, the provided error is encapsulated into a [InternalError](#errorsinternalerror) object, and the request's status is set to 500.
 
-#### `setResult(result, [status = 200])`
+#### `setResult(result, [options = null])`
 
-Adds a result to the request, and sets the request's status with the provided `status` argument.
+Sets the request's result.
  
 **Arguments**
 
 | Name | Type | Description                      |
 |------|------|----------------------------------|
 | `result` | *(varies)* | Request's result |
-| `status` | `integer` | HTTP status code |
+| `options` | `object` | Optional parameters |
+
+The `options` argument may contain the following properties:
+
+| Name | Type | Description                      | Default |
+|------|------|----------------------------------|---------|
+| `status` | `integer` | HTTP status code | `200` |
+| `headers` | `object` | Protocol specific headers | `null` |
+| `raw` | `boolean` | Asks Kuzzle to send the provided result directly, instead of encapsulating it in a Kuzzle response | `false` |
 
 ### Example
 
@@ -154,28 +162,30 @@ let request = new Request({
   foo: 'bar'
 });
 
-console.dir(request, {depth: null});
+console.dir(request.serialize(), {depth: null});
 ```
 
 Result:
 
 ```
-Request {
-  id: 'd53fab73-85ef-4494-a09e-2a47eb4147e1',
-  timestamp: 1480324424691,
-  status: 102,
-  error: null,
-  result: null,
-  input: 
-   RequestInput {
+{ data: 
+   { timestamp: 1482143102957,
+     requestId: '26d4ec6d-aafb-4ef8-951d-47666e5cf3ba',
+     jwt: null,
      metadata: { some: 'volatile data' },
      body: { document: 'content' },
      controller: 'write',
      action: 'create',
-     jwt: null,
-     resource: { index: 'foo', collection: 'bar', _id: 'some document ID' },
-     args: { foo: 'bar' } },
-  context: RequestContext { connectionId: null, protocol: null, token: null, user: null } }
+     index: 'foo',
+     collection: 'bar',
+     _id: 'some document ID',
+     foo: 'bar' },
+  options: 
+   { connectionId: null,
+     protocol: null,
+     result: null,
+     error: null,
+     status: 102 } }
 ```
 
 ## `RequestResponse`

--- a/lib/models/requestResponse.js
+++ b/lib/models/requestResponse.js
@@ -162,6 +162,7 @@ class RequestResponse {
     assert.assertString('header name', name);
     assert.assertString('header value', value);
 
+    // Handles specific HTTP headers
     switch(lowercased) {
       case 'age':
       case 'authorization':
@@ -179,9 +180,6 @@ class RequestResponse {
       case 'referer':
       case 'retry-after':
       case 'user-agent':
-        Object.keys(this[_headers])
-          .filter(key => key.toLowerCase() === lowercased)
-          .forEach(key => delete this[_headers][key]);
         this[_headers][lowercased] = value;
         break;
       case 'set-cookie':
@@ -193,14 +191,19 @@ class RequestResponse {
         }
         break;
       default:
+        /*
+         Non-HTTP headers might be case sensitive, so we
+         get rid of the "lowercased" constant here, except
+         when looking for the stored header
+          */
         const key = Object.keys(this[_headers])
           .find(key => key.toLowerCase() === lowercased);
 
         if (key) {
-          this[_headers][lowercased] += ', ' + value;
+          this[_headers][key] += ', ' + value;
         }
         else {
-          this[_headers][lowercased] = value;
+          this[_headers][name] = value;
         }
     }
 

--- a/lib/models/requestResponse.js
+++ b/lib/models/requestResponse.js
@@ -158,10 +158,10 @@ class RequestResponse {
    * @param {string} value
    */
   setHeader (name, value) {
-    const lowercased = name.toLowerCase();
-
     assert.assertString('header name', name);
     assert.assertString('header value', value);
+
+    const lowercased = name.toLowerCase();
 
     // Handles specific HTTP headers
     switch(lowercased) {

--- a/lib/models/requestResponse.js
+++ b/lib/models/requestResponse.js
@@ -233,6 +233,7 @@ class RequestResponse {
     if (this.raw === true) {
       return {
         raw: true,
+        requestId: this.requestId,
         content: this.result,
         headers: this.headers
       };
@@ -240,10 +241,11 @@ class RequestResponse {
 
     return {
       raw: false,
+      requestId: this.requestId,
       content: {
+        requestId: this.requestId,
         status: this.status,
         error: this.error,
-        requestId: this.requestId,
         controller: this.controller,
         action: this.action,
         collection: this.collection,

--- a/lib/models/requestResponse.js
+++ b/lib/models/requestResponse.js
@@ -17,6 +17,7 @@ const
 class RequestResponse {
   constructor (request) {
 
+    this.raw = false;
     this[_request] = request;
     this[_headers] = this[_request][Symbol.for('request.response.headers')];
 
@@ -229,7 +230,16 @@ class RequestResponse {
    * @returns {object}
    */
   toJSON () {
+    if (this.raw === true) {
+      return {
+        raw: true,
+        content: this.result,
+        headers: this.headers
+      };
+    }
+
     return {
+      raw: false,
       content: {
         status: this.status,
         error: this.error,

--- a/lib/models/requestResponse.js
+++ b/lib/models/requestResponse.js
@@ -224,18 +224,20 @@ class RequestResponse {
    * @returns {object}
    */
   toJSON () {
-    return Object.assign({}, {
-      status: this.status,
-      error: this.error,
-      requestId: this.requestId,
-      controller: this.controller,
-      action: this.action,
-      collection: this.collection,
-      index: this.index,
-      metadata: this.metadata,
-      headers: this.headers,
-      result: this.result
-    });
+    return {
+      content: {
+        status: this.status,
+        error: this.error,
+        requestId: this.requestId,
+        controller: this.controller,
+        action: this.action,
+        collection: this.collection,
+        index: this.index,
+        metadata: this.metadata,
+        result: this.result
+      },
+      headers: this.headers
+    };
   }
 }
 

--- a/lib/models/requestResponse.js
+++ b/lib/models/requestResponse.js
@@ -157,10 +157,12 @@ class RequestResponse {
    * @param {string} value
    */
   setHeader (name, value) {
+    const lowercased = name.toLowerCase();
+
     assert.assertString('header name', name);
     assert.assertString('header value', value);
 
-    switch(name.toLowerCase()) {
+    switch(lowercased) {
       case 'age':
       case 'authorization':
       case 'content-length':
@@ -178,9 +180,9 @@ class RequestResponse {
       case 'retry-after':
       case 'user-agent':
         Object.keys(this[_headers])
-          .filter(key => key.toLowerCase() === name.toLowerCase())
+          .filter(key => key.toLowerCase() === lowercased)
           .forEach(key => delete this[_headers][key]);
-        this[_headers][name] = value;
+        this[_headers][lowercased] = value;
         break;
       case 'set-cookie':
         if (!this[_headers]['set-cookie']) {
@@ -192,13 +194,13 @@ class RequestResponse {
         break;
       default:
         const key = Object.keys(this[_headers])
-          .find(key => key.toLowerCase() === name.toLowerCase());
+          .find(key => key.toLowerCase() === lowercased);
 
         if (key) {
-          this[_headers][key] += ', ' + value;
+          this[_headers][lowercased] += ', ' + value;
         }
         else {
-          this[_headers][name] = value;
+          this[_headers][lowercased] = value;
         }
     }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -196,20 +196,31 @@ class Request {
   /**
    * Sets the result and request status
    *
+   * Optional parameters can be provided with the "options" argument.
+   * This optional object may contain the following properties:
+   *   - status (number): HTTP status code (default: 200)
+   *   - headers (object): additional response protocol headers (default: null)
+   *   - raw (boolean): instead of a Kuzzle response, forward the result directly (default: false)
+   *
    * @param {Object} result - result content
-   * @param {Number} [status] - defaults to 200
-   * @param {Object} [headers] - defaults to null
+   * @param {Object} [options] - response options
    * @memberOf Request
    */
-  setResult(result, status, headers) {
+  setResult(result, options) {
+    options = options || {};
+
     if (result instanceof Error) {
       throw new InternalError('cannot set an error as a request\'s response');
     }
 
-    this.status = status || 200;
+    this.status = options.status || 200;
 
-    if (headers) {
-      this.response.setHeaders(headers);
+    if (options.headers) {
+      this.response.setHeaders(options.headers);
+    }
+
+    if (options.raw !== undefined) {
+      this.response.raw = options.raw;
     }
 
     this[_result] = result;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Common objects shared to various Kuzzle components and plugins",
   "main": "./index.js",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "dependencies": {
     "uuid": "^3.0.0"
   },

--- a/test/models/requestResponse.test.js
+++ b/test/models/requestResponse.test.js
@@ -186,24 +186,38 @@ describe('#RequestResponse', () => {
   });
 
   describe('toJSON', () => {
-    it('should return a valid JSON object', () => {
+    it('should return a valid JSON object in Kuzzle format', () => {
       let response = new RequestResponse(req);
 
       response.setHeader('x-foo', 'bar');
 
-      should(Object.keys(response.toJSON()))
-        .be.eql([
-          'status',
-          'error',
-          'requestId',
-          'controller',
-          'action',
-          'collection',
-          'index',
-          'metadata',
-          'headers',
-          'result'
-        ]);
+      should(response.toJSON()).have.properties(['raw', 'content', 'headers']);
+      should(response.toJSON().content).have.properties([
+        'status',
+        'error',
+        'requestId',
+        'controller',
+        'action',
+        'collection',
+        'index',
+        'metadata',
+        'result'
+      ]);
+      should(response.toJSON().raw).be.false();
+      should(response.toJSON().headers).match({'x-foo': 'bar'});
+    });
+
+    it('should return a valid JSON object in raw format', () => {
+      let response = new RequestResponse(req);
+
+      response.raw = true;
+      response.setHeader('x-foo', 'bar');
+      response.result = 'foobar';
+
+      should(response.toJSON()).have.properties(['raw', 'content', 'headers']);
+      should(response.toJSON().content).be.eql('foobar');
+      should(response.toJSON().raw).be.true();
+      should(response.toJSON().headers).match({'x-foo': 'bar'});
     });
   });
 

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -97,7 +97,7 @@ describe('#Request', () => {
 
   it('should set a custom status code if one is provided', () => {
     let result = {foo: 'bar'};
-    rq.setResult(result, 666);
+    rq.setResult(result, {status: 666});
 
     should(rq.result).be.exactly(result);
     should(rq.status).eql(666);
@@ -108,17 +108,17 @@ describe('#Request', () => {
   });
 
   it('should throw if trying to set a non-integer status', () => {
-    should(function () { rq.setResult('foobar', {}); }).throw('Attribute status must be an integer');
-    should(function () { rq.setResult('foobar', []); }).throw('Attribute status must be an integer');
-    should(function () { rq.setResult('foobar', true); }).throw('Attribute status must be an integer');
-    should(function () { rq.setResult('foobar', 123.45); }).throw('Attribute status must be an integer');
+    should(function () { rq.setResult('foobar', {status: {}}); }).throw('Attribute status must be an integer');
+    should(function () { rq.setResult('foobar', {status: []}); }).throw('Attribute status must be an integer');
+    should(function () { rq.setResult('foobar', {status: true}); }).throw('Attribute status must be an integer');
+    should(function () { rq.setResult('foobar', {status: 123.45}); }).throw('Attribute status must be an integer');
   });
 
   it('should throw if trying to set some non-object headers', () => {
-    should(() => { rq.setResult('foobar', undefined, 42); }).throw('Attribute headers must be of type "object"');
-    should(() => { rq.setResult('foobar', undefined, { a: true }); }).throw('Attribute headers must be of type "object" and have all its properties of type string.\nExpected "headers.a" to be of type "string", but go "boolean".');
-    should(() => { rq.setResult('foobar', undefined, 'bar'); }).throw('Attribute headers must be of type "object"');
-    should(() => { rq.setResult('foobar', undefined, true); }).throw('Attribute headers must be of type "object"');
+    should(() => { rq.setResult('foobar', {headers: 42}); }).throw('Attribute headers must be of type "object"');
+    should(() => { rq.setResult('foobar', {headers: { a: true }}); }).throw('Attribute headers must be of type "object" and have all its properties of type string.\nExpected "headers.a" to be of type "string", but go "boolean".');
+    should(() => { rq.setResult('foobar', {headers:  'bar'}); }).throw('Attribute headers must be of type "object"');
+    should(() => { rq.setResult('foobar', {headers:  true}); }).throw('Attribute headers must be of type "object"');
   });
 
   it('should build a well-formed response', () => {
@@ -142,7 +142,7 @@ describe('#Request', () => {
       request = new Request(data),
       response;
 
-    request.setResult(result, 201, responseHeaders);
+    request.setResult(result, {status: 201, headers: responseHeaders});
     request.setError(error);
 
     response = request.response;
@@ -184,7 +184,7 @@ describe('#Request', () => {
     serialized = request.serialize();
 
     let newRequest = new Request(serialized.data, serialized.options);
-    should(newRequest).match(request.response);
+    should(newRequest.response.toJSON()).match(request.response.toJSON());
     should(newRequest.timestamp).be.eql('timestamp');
   });
 });

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -121,6 +121,17 @@ describe('#Request', () => {
     should(() => { rq.setResult('foobar', {headers:  true}); }).throw('Attribute headers must be of type "object"');
   });
 
+  it('should set the raw response indicator if provided', () => {
+    let result = {foo: 'bar'};
+    
+    should(rq.response.raw).be.false();
+
+    rq.setResult(result, {raw: true});
+
+    should(rq.result).be.exactly(result);
+    should(rq.response.raw).be.true();
+  });
+
   it('should build a well-formed response', () => {
     let
       result = {foo: 'bar'},


### PR DESCRIPTION
Pre-requisite for https://github.com/kuzzleio/kuzzle/issues/586

* response format has been changed to avoid naming conflicts with the injected `headers` property inside the returned response content
* add an option to set a raw response, allowing for non-standard Kuzzle response. This has been deemed useful to allow plugins to return responses in other formats than JSON