### PR TITLE
proxy access logs - move status to the response root to unify respons…

### DIFF
--- a/lib/models/requestResponse.js
+++ b/lib/models/requestResponse.js
@@ -233,6 +233,7 @@ class RequestResponse {
     if (this.raw === true) {
       return {
         raw: true,
+        status: this.status,
         requestId: this.requestId,
         content: this.result,
         headers: this.headers
@@ -241,10 +242,10 @@ class RequestResponse {
 
     return {
       raw: false,
+      status: this.status,
       requestId: this.requestId,
       content: {
         requestId: this.requestId,
-        status: this.status,
         error: this.error,
         controller: this.controller,
         action: this.action,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Common objects shared to various Kuzzle components and plugins",
   "main": "./index.js",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "dependencies": {
     "uuid": "^3.0.0"
   },

--- a/test/models/requestResponse.test.js
+++ b/test/models/requestResponse.test.js
@@ -191,9 +191,8 @@ describe('#RequestResponse', () => {
 
       response.setHeader('x-foo', 'bar');
 
-      should(response.toJSON()).have.properties(['raw', 'content', 'headers']);
+      should(response.toJSON()).have.properties(['raw', 'status', 'requestId', 'content', 'headers']);
       should(response.toJSON().content).have.properties([
-        'status',
         'error',
         'requestId',
         'controller',
@@ -213,8 +212,10 @@ describe('#RequestResponse', () => {
       response.raw = true;
       response.setHeader('x-foo', 'bar');
       response.result = 'foobar';
+      response.status = 666;
 
       should(response.toJSON()).have.properties(['raw', 'content', 'headers']);
+      should(response.toJSON().status).be.eql(666);
       should(response.toJSON().content).be.eql('foobar');
       should(response.toJSON().raw).be.true();
       should(response.toJSON().headers).match({'x-foo': 'bar'});


### PR DESCRIPTION
…es sent to proxy between http and other protocols

prerequisite for https://github.com/kuzzleio/kuzzle-proxy/pull/44

[The previous PR](https://github.com/kuzzleio/kuzzle-common-objects/pull/13) has introduced a split in the response between the content and the metadata, mainly to support raw responses.

The status has not been moved from the content yet, which prevents unfiying the response sent to the proxy for all protocols.
This PR moved the status to the root level of the Request.response object, which allows to send a custom status code along a raw response (i.e. a 201 code) and simplify the access log data extraction.