### PR TITLE
Status needs to be duplicated between the content and the main enveloppe

### DIFF
--- a/lib/errors/kuzzleError.js
+++ b/lib/errors/kuzzleError.js
@@ -22,7 +22,11 @@ inherits(KuzzleError, Error);
 KuzzleError.prototype.name = 'KuzzleError';
 
 KuzzleError.prototype.toJSON = function () {
-  return this;
+  return {
+    message: this.message,
+    status: this.status,
+    stack: this.stack
+  };
 };
 
 /**

--- a/lib/errors/pluginImplementationError.js
+++ b/lib/errors/pluginImplementationError.js
@@ -3,7 +3,8 @@ var
   KuzzleError = require('./kuzzleError');
 
 function PluginImplementationError(message) {
-  KuzzleError.call(this, message + '\nThis is probably not a Kuzzle error, but a problem with a plugin implementation.', 500);
+  KuzzleError.call(this, message, 500);
+  this.message += '\nThis is probably not a Kuzzle error, but a problem with a plugin implementation.';
 }
 inherits(PluginImplementationError, KuzzleError);
 PluginImplementationError.prototype.name = 'PluginImplementationError';

--- a/lib/models/requestResponse.js
+++ b/lib/models/requestResponse.js
@@ -246,6 +246,7 @@ class RequestResponse {
       requestId: this.requestId,
       content: {
         requestId: this.requestId,
+        status: this.status,
         error: this.error,
         controller: this.controller,
         action: this.action,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Common objects shared to various Kuzzle components and plugins",
   "main": "./index.js",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "dependencies": {
     "uuid": "^3.0.0"
   },

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -68,7 +68,7 @@ describe('#Request', () => {
     should(rq.error).be.exactly(foo);
     should(rq.status).eql(666);
 
-    should(rq.error.toJSON()).be.exactly(foo);
+    should(rq.error.toJSON()).match(foo);
   });
 
   it('should wrap a plain Error object into an InternalError one', () => {


### PR DESCRIPTION
Following #14, we missed the fact non http protocols were outputing the content only and still need the status.
The only drawback is that for http, we will get the status twice, once in the http status code and once in the body but this simplifies a lot the rest of the process.

Edit: also fixes #16
