### PR TITLE
Track triggered events

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  range: "80...100"
+
+  status:
+    project:
+      default:
+        threshold: 1
+
+    patch:
+      default:
+        branches:
+          - master

--- a/lib/request.js
+++ b/lib/request.js
@@ -18,7 +18,8 @@ const
   _result = Symbol(),
   _context = Symbol(),
   _timestamp = Symbol(),
-  _response = Symbol();
+  _response = Symbol(),
+  _triggered = Symbol();
 
 /**
  * Builds a Kuzzle normalized request object
@@ -74,6 +75,7 @@ class Request {
     this[_result] = null;
     this[_context] = new RequestContext(options);
     this[_response] = null;
+    this[_triggered] = [];
 
     this.id = data.requestId ? assert.assertString('requestId', data.requestId) : uuid.v4();
     this[_timestamp] = data.timestamp || Date.now();
@@ -175,6 +177,25 @@ class Request {
       this[_response] = new RequestResponse(this);
     }
     return this[_response];
+  }
+
+  /**
+   * Tells if this request triggered the event "event" or not
+   * @param {string} event
+   * @return {Boolean}
+   */
+  hasTriggered(event) {
+    return this[_triggered].includes(event);
+  }
+
+  /**
+   * Adds the event "event" to the list of triggered events
+   * @param {string} event
+   */
+  triggers(event) {
+    if (!this.hasTriggered(event)) {
+      this[_triggered].push(event);
+    }
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "npm run --silent lint && npm run unit-testing --coverage",
     "unit-testing": "istanbul test _mocha",
     "lint": "eslint --max-warnings=0 index.js ./errors ./models ./test",
-    "codecov": "cat ./coverage/lcov.info | ./node_modules/.bin/codecov"
+    "codecov": "codecov"
   },
   "repository": {
     "type": "git",

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -198,4 +198,15 @@ describe('#Request', () => {
     should(newRequest.response.toJSON()).match(request.response.toJSON());
     should(newRequest.timestamp).be.eql('timestamp');
   });
+
+  it('should track the list of triggered events', () => {
+    let request = new Request({});
+
+    should(request.hasTriggered('foobar')).be.false();
+    request.triggers('foobar');
+    should(request.hasTriggered('foobar')).be.true();
+
+    request.triggers('barfoo');
+    should(request.hasTriggered('foobar')).be.true();
+  });
 });


### PR DESCRIPTION
Pre-requisite to fix the following issue: https://github.com/kuzzleio/kuzzle/issues/591

Add a new property in the `Request` object to allow tracking of triggered events. Will be used by Kuzzle Core to prevent infinite event loops from concurrent plugins API calls.

# Unrelated changes

* make travis use Node 6.x instead of Node 4.x, allowing to use ES6 extensions
* fix codecov reporting