### PR TITLE
Fix PartialError objects serialization

### DIFF
--- a/lib/errors/partialError.js
+++ b/lib/errors/partialError.js
@@ -1,4 +1,4 @@
-var
+const
   inherits = require('util').inherits,
   KuzzleError = require('./kuzzleError');
 

--- a/lib/errors/partialError.js
+++ b/lib/errors/partialError.js
@@ -12,4 +12,14 @@ function PartialError(message, body) {
 inherits(PartialError, KuzzleError);
 PartialError.prototype.name = 'PartialError';
 
+PartialError.prototype.toJSON = function () {
+  return {
+    message: this.message,
+    status: this.status,
+    stack: this.stack,
+    errors: this.errors,
+    count: this.count
+  };
+};
+
 module.exports = PartialError;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Common objects shared to various Kuzzle components and plugins",
   "main": "./index.js",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "dependencies": {
     "uuid": "^3.0.0"
   },

--- a/test/errors/partialError.test.js
+++ b/test/errors/partialError.test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const
+  should = require('should'),
+  PartialError = require.main.require('lib/errors/partialError');
+
+describe('#PartialError', () => {
+  it('should create a well-formed object with no body provided', () => {
+    let err = new PartialError('foobar');
+
+    should(err.message).be.eql('foobar');
+    should(err.status).be.eql(206);
+    should(err.name).be.eql('PartialError');
+    should(err.errors).be.undefined();
+    should(err.count).be.undefined();
+  });
+
+  it('should create a well-formed object with a body provided', () => {
+    let err = new PartialError('foobar', ['foo', 'bar']);
+
+    should(err.message).be.eql('foobar');
+    should(err.status).be.eql(206);
+    should(err.name).be.eql('PartialError');
+    should(err.errors).be.eql(['foo', 'bar']);
+    should(err.count).be.eql(2);
+  });
+
+  it('should serialize correctly', () => {
+    let err = JSON.parse(JSON.stringify(new PartialError('foobar', ['foo', 'bar'])));
+
+    should(err.message).be.eql('foobar');
+    should(err.status).be.eql(206);
+    should(err.errors).be.eql(['foo', 'bar']);
+    should(err.count).be.eql(2);
+  });
+});


### PR DESCRIPTION
# Description

Add a dedicated serialization method to this object instead of relying only on the one in the abstract `KuzzleError` object.

# Solved Issue

#20 
