### PR TITLE
Add ExternalServiceError error constructor

### DIFF
--- a/lib/errors/externalServiceError.js
+++ b/lib/errors/externalServiceError.js
@@ -1,11 +1,12 @@
 const
-  inherits = require('util').inherits,
   KuzzleError = require('./kuzzleError');
 
-function ExternalServiceError(message) {
-  KuzzleError.call(this, message, 500);
+class ExternalServiceError extends KuzzleError {
+  constructor(message) {
+    super(message, 500);
+  }
 }
-inherits(ExternalServiceError, KuzzleError);
+
 ExternalServiceError.prototype.name = 'ExternalServiceError';
 
 module.exports = ExternalServiceError;

--- a/lib/errors/externalServiceError.js
+++ b/lib/errors/externalServiceError.js
@@ -1,0 +1,11 @@
+const
+  inherits = require('util').inherits,
+  KuzzleError = require('./kuzzleError');
+
+function ExternalServiceError(message) {
+  KuzzleError.call(this, message, 500);
+}
+inherits(ExternalServiceError, KuzzleError);
+ExternalServiceError.prototype.name = 'ExternalServiceError';
+
+module.exports = ExternalServiceError;

--- a/test/errors/externalServiceError.test.js
+++ b/test/errors/externalServiceError.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const
+  should = require('should'),
+  ExternalServiceError = require.main.require('lib/errors/externalServiceError');
+
+describe('#ExternalServiceError', () => {
+  it('should create a well-formed object', () => {
+    let err = new ExternalServiceError('foobar');
+
+    should(err.message).be.eql('foobar');
+    should(err.status).be.eql(500);
+    should(err.name).be.eql('ExternalServiceError');
+  });
+
+  it('should serialize correctly', () => {
+    let err = JSON.parse(JSON.stringify(new ExternalServiceError('foobar')));
+
+    should(err.message).be.eql('foobar');
+    should(err.status).be.eql(500);
+
+  });
+});


### PR DESCRIPTION
# Description

Adds a new error type, to be used to notify Kuzzle and clients about unusual errors coming from external services such as Elasticsearch or Redis.

"Unusual error" == any error which is not a bad request nor a service unavailable error

# Related issue

https://github.com/kuzzleio/kuzzle/issues/731
