### PR TITLE
Keep track of requests chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ This constructor is used to transform an [API request](http://kuzzle.io/api-refe
 |------|------|----------------------------------|
 | `timestamp` | integer | Request creation timestamp |
 
+**Read-only**
+
+The following attributes can be set after the object has been built, but once set, they cannot be changed:
+
+| Name | Type | default | Description                      |
+|------|------|---------|----------------------------------|
+| `origin` | `Request` | `null` | The first request of a requests chain |
+| `previous` | `Request` | `null` | The previous request of a requests chain |
+
 **Writable**
 
 | Name | Type | default | Description                      |

--- a/lib/request.js
+++ b/lib/request.js
@@ -19,7 +19,9 @@ const
   _context = Symbol(),
   _timestamp = Symbol(),
   _response = Symbol(),
-  _triggered = Symbol();
+  _triggered = Symbol(),
+  _origin = Symbol(),
+  _previous = Symbol();
 
 /**
  * Builds a Kuzzle normalized request object
@@ -41,6 +43,14 @@ const
 /**
  * @name Request#id
  * @type {string}
+ */
+/**
+ * @name Request#origin
+ * @type {Request}
+ */
+/**
+ * @name Request#previous
+ * @type {Request}
  */
 /**
  * @name Request#input
@@ -76,6 +86,8 @@ class Request {
     this[_context] = new RequestContext(options);
     this[_response] = null;
     this[_triggered] = [];
+    this[_origin] = null;
+    this[_previous] = null;
 
     this.id = data.requestId ? assert.assertString('requestId', data.requestId) : uuid.v4();
     this[_timestamp] = data.timestamp || Date.now();
@@ -126,6 +138,52 @@ class Request {
    */
   get status () {
     return this[_status];
+  }
+
+  /**
+   * Request origin getter
+   * @returns {Request}
+   */
+  get origin () {
+    return this[_origin];
+  }
+
+  /**
+   * Request origin setter
+   * Can only be set once
+   * @param {Request} o - origin request
+   */
+  set origin (o) {
+    if (!(o instanceof Request)) {
+      throw new InternalError('Can only set a Request object as a request origin');
+    }
+
+    if (!this[_origin]) {
+      this[_origin] = o.origin === null ? o : o.origin;
+    }
+  }
+
+  /**
+   * Previous request getter
+   * @returns {Request}
+   */
+  get previous () {
+    return this[_previous];
+  }
+
+  /**
+   * Previous request setter
+   * Can only be set once
+   * @param {Request} p - origin request
+   */
+  set previous (p) {
+    if (!(p instanceof Request)) {
+      throw new InternalError('Can only set a Request object as a previous request');
+    }
+
+    if (!this[_previous]) {
+      this[_previous] = p;
+    }
   }
 
   /**
@@ -180,11 +238,18 @@ class Request {
   }
 
   /**
-   * Tells if this request triggered the event "event" or not
+   * Tells if this request triggered the event "event" or not.
+   * If in a request chain, then the origin request holds the
+   * list of triggered events
+   *
    * @param {string} event
    * @return {Boolean}
    */
   hasTriggered(event) {
+    if (this[_origin]) {
+      return this[_origin][_triggered].includes(event);
+    }
+
     return this[_triggered].includes(event);
   }
 
@@ -194,7 +259,12 @@ class Request {
    */
   triggers(event) {
     if (!this.hasTriggered(event)) {
-      this[_triggered].push(event);
+      if (this[_origin]) {
+        this[_origin][_triggered].push(event);
+      }
+      else {
+        this[_triggered].push(event);
+      }
     }
   }
 

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -123,7 +123,7 @@ describe('#Request', () => {
 
   it('should set the raw response indicator if provided', () => {
     let result = {foo: 'bar'};
-    
+
     should(rq.response.raw).be.false();
 
     rq.setResult(result, {raw: true});
@@ -208,5 +208,79 @@ describe('#Request', () => {
 
     request.triggers('barfoo');
     should(request.hasTriggered('foobar')).be.true();
+  });
+
+  it('should keep track of previously triggered events in the origin request', () => {
+    const
+      origin = new Request({}),
+      request = new Request({});
+
+    request.origin = origin;
+
+    should(request.hasTriggered('foobar')).be.false();
+    should(origin.hasTriggered('foobar')).be.false();
+
+    request.triggers('foobar');
+    should(request.hasTriggered('foobar')).be.true();
+    should(origin.hasTriggered('foobar')).be.true();
+  });
+
+  it('should not overwrite a previously set origin', () => {
+    let
+      request = new Request({}),
+      origin = new Request({});
+
+    should(request.origin).be.null();
+
+    request.origin = origin;
+    should(request.origin).be.eql(origin);
+
+    request.origin = new Request({});
+    should(request.origin).be.eql(origin);
+  });
+
+  it('should set the request origin when invoking the origin setter', () => {
+    let
+      origin = new Request({}),
+      request1 = new Request({}),
+      request2 = new Request({});
+
+    request1.origin = origin;
+    request2.origin = request1;
+
+    should(request1.origin).be.eql(origin);
+    should(request2.origin).be.eql(origin);
+  });
+
+  it('should not overwrite a previously set previous request', () => {
+    let
+      request = new Request({}),
+      previous = new Request({});
+
+    should(request.previous).be.null();
+
+    request.previous = previous;
+    should(request.previous).be.eql(previous);
+
+    request.previous = new Request({});
+    should(request.previous).be.eql(previous);
+  });
+
+  it('should throw if a non-Request is provided as a previous request', () => {
+    let request = new Request({});
+
+    should(() => { request.previous = 'foobar'; }).throw(InternalError);
+    should(() => { request.previous = null; }).throw(InternalError);
+    should(() => { request.previous = true; }).throw(InternalError);
+    should(() => { request.previous = 123; }).throw(InternalError);
+  });
+
+  it('should throw if a non-Request is provided as a request origin', () => {
+    let request = new Request({});
+
+    should(() => { request.origin = 'foobar'; }).throw(InternalError);
+    should(() => { request.origin = null; }).throw(InternalError);
+    should(() => { request.origin = true; }).throw(InternalError);
+    should(() => { request.origin = 123; }).throw(InternalError);
   });
 });


### PR DESCRIPTION
# Description

This pull request answers to two needs at once, both for kuzzle plugins executing multiple Kuzzle API actions:

* when a global event is triggered on an API request (such as `request:onError`), plugins handling such events need to know the origin request, and where in the request chain the current request stands
* when a requests chain trigger events, we need to prevent infinite loop to occur. Such a system already exists but there is a case where the current protection does not work (see #24)

# Changes

* Add a new `origin` property, accepting only a `Request` reference:
  * used by Kuzzle to set the starting point of a request chain
  * read-only once set
  * the setter will get the origin of the provided request reference, and set it as its own request origin
* `request.triggers(event)` now register events in the `origin` request, if set
* `request.hasTriggered(event)` now search for the provided event in the `origin` request, if set
* Add a new `previous` property, accepting only a `Request` reference. This property is only provided as a conveniance for plugin developers.

# Solved Issue

#24

# Documentation

https://github.com/kuzzleio/documentation/pull/173
