### PR TITLE
Do not add stack in response if NODE_ENV is not development

### DIFF
--- a/lib/errors/kuzzleError.js
+++ b/lib/errors/kuzzleError.js
@@ -11,10 +11,14 @@ function KuzzleError(message, status) {
   this.status = status;
   if (util.isError(message)) {
     this.message = message.message;
-    this.stack = message.stack;
+    if (process.env.NODE_ENV !== 'production') {
+      this.stack = message.stack;
+    }
   } else {
     this.message = message;
-    this.stack = (new Error()).stack;
+    if (process.env.NODE_ENV !== 'production') {
+      this.stack = (new Error()).stack;
+    }
   }
 }
 inherits(KuzzleError, Error);

--- a/lib/errors/kuzzleError.js
+++ b/lib/errors/kuzzleError.js
@@ -11,14 +11,10 @@ function KuzzleError(message, status) {
   this.status = status;
   if (util.isError(message)) {
     this.message = message.message;
-    if (process.env.NODE_ENV !== 'production') {
-      this.stack = message.stack;
-    }
+    this.stack = message.stack;
   } else {
     this.message = message;
-    if (process.env.NODE_ENV !== 'production') {
-      this.stack = (new Error()).stack;
-    }
+    this.stack = (new Error()).stack;
   }
 }
 inherits(KuzzleError, Error);

--- a/lib/request.js
+++ b/lib/request.js
@@ -285,9 +285,12 @@ class Request {
     if (process.env.NODE_ENV === 'development') {
       this[_error] = kuzzleError;
     } else {
-      this[_error] = {
-        message: kuzzleError.message
-      };
+      this[_error] = {};
+      Object.keys(kuzzleError.toJSON())
+        .filter(property => property !== 'stack')
+        .forEach(property => {
+          this[_error][property] = kuzzleError[property];
+        });
     }
 
     this.status = kuzzleError.status;

--- a/lib/request.js
+++ b/lib/request.js
@@ -280,8 +280,17 @@ class Request {
       throw new InternalError('cannot set non-error object as a request\'s error');
     }
 
-    this[_error] = error instanceof KuzzleError ? error : new InternalError(error);
-    this.status = this[_error].status;
+    let kuzzleError = error instanceof KuzzleError ? error : new InternalError(error);
+
+    if (process.env.NODE_ENV === 'development') {
+      this[_error] = kuzzleError;
+    } else {
+      this[_error] = {
+        message: kuzzleError.message
+      };
+    }
+
+    this.status = kuzzleError.status;
   }
 
   /**

--- a/test/models/requestResponse.test.js
+++ b/test/models/requestResponse.test.js
@@ -42,6 +42,12 @@ describe('#RequestResponse', () => {
   });
 
   describe('#properties', () => {
+    let currentEnv = process.env.NODE_ENV;
+
+    afterEach(() => {
+      process.env.NODE_ENV = currentEnv;
+    });
+
     it('should set the request status', () => {
       const response = new RequestResponse(req);
 
@@ -54,9 +60,28 @@ describe('#RequestResponse', () => {
         error = new ParseError('test'),
         response = new RequestResponse(req);
 
+      process.env.NODE_ENV = 'development';
+
       response.error = error;
       should(req.error).be.exactly(error);
       should(req.status).be.exactly(error.status);
+
+      process.env.NODE_ENV = currentEnv;
+    });
+
+    it('should set the request error without stack if the environment is different than development', () => {
+      const
+        error = new ParseError('test'),
+        response = new RequestResponse(req);
+
+      process.env.NODE_ENV = 'production';
+
+      response.error = error;
+      should(req.error.stack).be.undefined();
+      should(req.error.message).be.exactly(error.message);
+      should(req.status).be.exactly(error.status);
+
+      process.env.NODE_ENV = currentEnv;
     });
 
     it('should set the request result', () => {

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -10,9 +10,14 @@ const
 
 describe('#Request', () => {
   let rq;
+  let currentEnv = process.env.NODE_ENV;
 
   beforeEach(() => {
     rq = new Request({});
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = currentEnv;
   });
 
   it('should defaults other properties correctly', () => {
@@ -24,6 +29,8 @@ describe('#Request', () => {
   });
 
   it('should initialize the request object with the provided options', () => {
+    process.env.NODE_ENV = 'development';
+
     let
       result = {foo: 'bar'},
       error = new InternalError('foobar'),
@@ -61,6 +68,8 @@ describe('#Request', () => {
   });
 
   it('should set an error properly', () => {
+    process.env.NODE_ENV = 'development';
+
     let foo = new KuzzleError('bar', 666);
 
     rq.setError(foo);
@@ -72,6 +81,7 @@ describe('#Request', () => {
   });
 
   it('should wrap a plain Error object into an InternalError one', () => {
+    process.env.NODE_ENV = 'development';
     let foo = new Error('bar');
 
     rq.setError(foo);
@@ -133,6 +143,7 @@ describe('#Request', () => {
   });
 
   it('should build a well-formed response', () => {
+    process.env.NODE_ENV = 'development';
     let
       result = {foo: 'bar'},
       responseHeaders = {
@@ -171,6 +182,7 @@ describe('#Request', () => {
   });
 
   it('should serialize the request correctly', () => {
+    process.env.NODE_ENV = 'development';
     let
       result = {foo: 'bar'},
       error = new InternalError('foobar'),


### PR DESCRIPTION
# Description
Not sending to the user the stack trace if `NODE_ENV` is different than "development". 
The error is still logged in Kuzzle (via `triggerPlugin('log:error')`)

# Related issue
* https://github.com/kuzzleio/kuzzle/issues/747