### PR TITLE
Unserialize error objects instead of throwing an exception

### DIFF
--- a/lib/errors/badRequestError.js
+++ b/lib/errors/badRequestError.js
@@ -1,11 +1,13 @@
-var
-  inherits = require('util').inherits,
-  KuzzleError = require('./kuzzleError');
+const KuzzleError = require('./kuzzleError');
 
-function BadRequestError(message) {
-  KuzzleError.call(this, message, 400);
+class BadRequestError extends KuzzleError {
+  constructor(message) {
+    super(message, 400);
+  }
+
+  get name() {
+    return 'BadRequestError';
+  }
 }
-inherits(BadRequestError, KuzzleError);
-BadRequestError.prototype.name = 'BadRequestError';
 
 module.exports = BadRequestError;

--- a/lib/errors/externalServiceError.js
+++ b/lib/errors/externalServiceError.js
@@ -1,12 +1,13 @@
-const
-  KuzzleError = require('./kuzzleError');
+const KuzzleError = require('./kuzzleError');
 
 class ExternalServiceError extends KuzzleError {
   constructor(message) {
     super(message, 500);
   }
-}
 
-ExternalServiceError.prototype.name = 'ExternalServiceError';
+  get name () {
+    return 'ExternalServiceError';
+  }
+}
 
 module.exports = ExternalServiceError;

--- a/lib/errors/forbiddenError.js
+++ b/lib/errors/forbiddenError.js
@@ -1,11 +1,13 @@
-var
-  inherits = require('util').inherits,
-  KuzzleError = require('./kuzzleError');
+const KuzzleError = require('./kuzzleError');
 
-function ForbiddenError(message) {
-  KuzzleError.call(this, message, 403);
+class ForbiddenError extends KuzzleError {
+  constructor (message) {
+    super(message, 403);
+  }
+
+  get name () {
+    return 'ForbiddenError';
+  }
 }
-inherits(ForbiddenError, KuzzleError);
-ForbiddenError.prototype.name = 'ForbiddenError';
 
 module.exports = ForbiddenError;

--- a/lib/errors/gatewayTimeoutError.js
+++ b/lib/errors/gatewayTimeoutError.js
@@ -1,11 +1,13 @@
-var
-  inherits = require('util').inherits,
-  KuzzleError = require('./kuzzleError');
+const KuzzleError = require('./kuzzleError');
 
-function GatewayTimeoutError(message) {
-  KuzzleError.call(this, message, 504);
+class GatewayTimeoutError extends KuzzleError {
+  constructor (message) {
+    super(message, 504);
+  }
+
+  get name () {
+    return 'GatewayTimeoutError';
+  }
 }
-inherits(GatewayTimeoutError, KuzzleError);
-GatewayTimeoutError.prototype.name = 'GatewayTimeoutError';
 
 module.exports = GatewayTimeoutError;

--- a/lib/errors/internalError.js
+++ b/lib/errors/internalError.js
@@ -1,11 +1,13 @@
-var
-  inherits = require('util').inherits,
-  KuzzleError = require('./kuzzleError');
+const KuzzleError = require('./kuzzleError');
 
-function InternalError(message) {
-  KuzzleError.call(this, message, 500);
+class InternalError extends KuzzleError {
+  constructor (message) {
+    super(message, 500);
+  }
+
+  get name () {
+    return 'InternalError';
+  }
 }
-inherits(InternalError, KuzzleError);
-InternalError.prototype.name = 'InternalError';
 
 module.exports = InternalError;

--- a/lib/errors/kuzzleError.js
+++ b/lib/errors/kuzzleError.js
@@ -1,33 +1,37 @@
-var
-  inherits = require('util').inherits,
-  util = require('util');
+const util = require('util');
 
 /**
  * @param message
  * @param status
  * @constructor
  */
-function KuzzleError(message, status) {
-  this.status = status;
-  if (util.isError(message)) {
-    this.message = message.message;
-    this.stack = message.stack;
-  } else {
-    this.message = message;
-    this.stack = (new Error()).stack;
+class KuzzleError extends Error {
+  constructor (message, status) {
+    super(message);
+
+    this.status = status;
+
+    if (util.isError(message)) {
+      this.message = message.message;
+      this.stack = message.stack;
+    } else {
+      this.message = message;
+      Error.captureStackTrace(this, KuzzleError);
+    }
+  }
+
+  get name () {
+    return 'KuzzleError';
+  }
+
+  toJSON () {
+    return {
+      message: this.message,
+      status: this.status,
+      stack: this.stack
+    };
   }
 }
-inherits(KuzzleError, Error);
-
-KuzzleError.prototype.name = 'KuzzleError';
-
-KuzzleError.prototype.toJSON = function () {
-  return {
-    message: this.message,
-    status: this.status,
-    stack: this.stack
-  };
-};
 
 /**
  * @type {KuzzleError}

--- a/lib/errors/notFoundError.js
+++ b/lib/errors/notFoundError.js
@@ -1,11 +1,13 @@
-var
-  inherits = require('util').inherits,
-  KuzzleError = require('./kuzzleError');
+const KuzzleError = require('./kuzzleError');
 
-function NotFoundError(message) {
-  KuzzleError.call(this, message, 404);
+class NotFoundError extends KuzzleError {
+  constructor (message) {
+    super(message, 404);
+  }
+
+  get name () {
+    return 'NotFoundError';
+  }
 }
-inherits(NotFoundError, KuzzleError);
-NotFoundError.prototype.name = 'NotFoundError';
 
 module.exports = NotFoundError;

--- a/lib/errors/parseError.js
+++ b/lib/errors/parseError.js
@@ -1,11 +1,13 @@
-var
-  inherits = require('util').inherits,
-  KuzzleError = require('./kuzzleError');
+const KuzzleError = require('./kuzzleError');
 
-function ParseError(message) {
-  KuzzleError.call(this, message, 400);
+class ParseError extends KuzzleError {
+  constructor (message) {
+    super(message, 400);
+  }
+
+  get name () {
+    return 'ParseError';
+  }
 }
-inherits(ParseError, KuzzleError);
-ParseError.prototype.name = 'ParseError';
 
 module.exports = ParseError;

--- a/lib/errors/partialError.js
+++ b/lib/errors/partialError.js
@@ -1,25 +1,26 @@
-const
-  inherits = require('util').inherits,
-  KuzzleError = require('./kuzzleError');
+const KuzzleError = require('./kuzzleError');
 
-function PartialError(message, body) {
-  KuzzleError.call(this, message, 206);
-  if (body) {
+class PartialError extends KuzzleError {
+  constructor (message, body = []) {
+    super(message, 206);
+
     this.errors = body;
     this.count = body.length;
   }
-}
-inherits(PartialError, KuzzleError);
-PartialError.prototype.name = 'PartialError';
 
-PartialError.prototype.toJSON = function () {
-  return {
-    message: this.message,
-    status: this.status,
-    stack: this.stack,
-    errors: this.errors,
-    count: this.count
-  };
-};
+  get name () {
+    return 'PartialError';
+  }
+
+  toJSON () {
+    return {
+      message: this.message,
+      status: this.status,
+      stack: this.stack,
+      errors: this.errors,
+      count: this.count
+    };
+  }
+}
 
 module.exports = PartialError;

--- a/lib/errors/pluginImplementationError.js
+++ b/lib/errors/pluginImplementationError.js
@@ -1,12 +1,14 @@
-var
-  inherits = require('util').inherits,
-  KuzzleError = require('./kuzzleError');
+const KuzzleError = require('./kuzzleError');
 
-function PluginImplementationError(message) {
-  KuzzleError.call(this, message, 500);
-  this.message += '\nThis is probably not a Kuzzle error, but a problem with a plugin implementation.';
+class PluginImplementationError extends KuzzleError {
+  constructor (message) {
+    super(message, 500);
+    this.message += '\nThis is probably not a Kuzzle error, but a problem with a plugin implementation.';
+  }
+
+  get name () {
+    return 'PluginImplementationError';
+  }
 }
-inherits(PluginImplementationError, KuzzleError);
-PluginImplementationError.prototype.name = 'PluginImplementationError';
 
 module.exports = PluginImplementationError;

--- a/lib/errors/preconditionError.js
+++ b/lib/errors/preconditionError.js
@@ -1,11 +1,13 @@
-var
-  inherits = require('util').inherits,
-  KuzzleError = require('./kuzzleError');
+const KuzzleError = require('./kuzzleError');
 
-function PreconditionError(message) {
-  KuzzleError.call(this, message, 412);
+class PreconditionError extends KuzzleError {
+  constructor (message) {
+    super(message, 412);
+  }
+
+  get name () {
+    return 'Precondition Failed';
+  }
 }
-inherits(PreconditionError, KuzzleError);
-PreconditionError.prototype.name = 'Precondition Failed';
 
 module.exports = PreconditionError;

--- a/lib/errors/serviceUnavailableError.js
+++ b/lib/errors/serviceUnavailableError.js
@@ -1,11 +1,13 @@
-var
-  inherits = require('util').inherits,
-  KuzzleError = require('./kuzzleError');
+const KuzzleError = require('./kuzzleError');
 
-function ServiceUnavailable(message) {
-  KuzzleError.call(this, message, 503);
+class ServiceUnavailable extends KuzzleError {
+  constructor (message) {
+    super(message, 503);
+  }
+
+  get name () {
+    return 'ServiceUnavailable';
+  }
 }
-inherits(ServiceUnavailable, KuzzleError);
-ServiceUnavailable.prototype.name = 'ServiceUnavailable';
 
 module.exports = ServiceUnavailable;

--- a/lib/errors/sizeLimitError.js
+++ b/lib/errors/sizeLimitError.js
@@ -1,11 +1,13 @@
-var
-  inherits = require('util').inherits,
-  KuzzleError = require('./kuzzleError');
+const KuzzleError = require('./kuzzleError');
 
-function SizeLimitError(message) {
-  KuzzleError.call(this, message, 413);
+class SizeLimitError extends KuzzleError {
+  constructor (message) {
+    super(message, 413);
+  }
+
+  get name () {
+    return 'SizeLimitError';
+  }
 }
-inherits(SizeLimitError, KuzzleError);
-SizeLimitError.prototype.name = 'SizeLimitError';
 
 module.exports = SizeLimitError;

--- a/lib/errors/unauthorizedError.js
+++ b/lib/errors/unauthorizedError.js
@@ -1,17 +1,21 @@
-var
-  inherits = require('util').inherits,
-  KuzzleError = require('./kuzzleError');
+const KuzzleError = require('./kuzzleError');
 
-function UnauthorizedError(message) {
-  KuzzleError.call(this, message, 401);
+class UnauthorizedError extends KuzzleError {
+  constructor (message) {
+    super(message, 401);
+  }
+
+  get name () {
+    return 'UnauthorizedError';
+  }
+
+  get subCodes () {
+    return {
+      TokenExpired: 1,
+      JsonWebTokenError: 2,
+      AuthenticationError: 3
+    };
+  }
 }
-inherits(UnauthorizedError, KuzzleError);
-UnauthorizedError.prototype.name = 'UnauthorizedError';
-
-UnauthorizedError.prototype.subCodes = {
-  TokenExpired: 1,
-  JsonWebTokenError: 2,
-  AuthenticationError: 3
-};
 
 module.exports = UnauthorizedError;

--- a/lib/request.js
+++ b/lib/request.js
@@ -113,7 +113,18 @@ class Request {
       }
 
       if (options.error) {
-        this.setError(options.error);
+        if (options.error instanceof Error) {
+          this.setError(options.error);
+        }
+        else {
+          const error = new KuzzleError(options.error.message, options.error.status || 500);
+
+          for (const prop of Object.keys(options.error).filter(key => key !== 'message' && key !== 'status')) {
+            error[prop] = options.error[prop];
+          }
+
+          this.setError(error);
+        }
       }
 
       if (options.status) {

--- a/test/errors/partialError.test.js
+++ b/test/errors/partialError.test.js
@@ -11,8 +11,8 @@ describe('#PartialError', () => {
     should(err.message).be.eql('foobar');
     should(err.status).be.eql(206);
     should(err.name).be.eql('PartialError');
-    should(err.errors).be.undefined();
-    should(err.count).be.undefined();
+    should(err.errors).be.an.Array().and.be.empty();
+    should(err.count).be.eql(0);
   });
 
   it('should create a well-formed object with a body provided', () => {

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -41,6 +41,37 @@ describe('#Request', () => {
     should(request.status).eql(666);
     should(request.result).be.exactly(result);
     should(request.error).be.exactly(error);
+    should(request.error).be.instanceOf(KuzzleError);
+    should(request.error.message).be.exactly(error.message);
+    should(request.error.stack).be.exactly(error.stack);
+    should(request.error.status).be.exactly(request.error.status);
+    should(request.context.protocol).eql('protocol');
+    should(request.context.connectionId).eql('connectionId');
+    should(request.context.token).match({token: 'token'});
+    should(request.context.user).match({user: 'user'});
+  });
+
+  it('should instanciate a new KuzzleError object from a serialized error', () => {
+    let
+      result = {foo: 'bar'},
+      error = new InternalError('foobar'),
+      options = {
+        status: 666,
+        result,
+        error: error.toJSON(),
+        connectionId: 'connectionId',
+        protocol: 'protocol',
+        token: {token: 'token'},
+        user: { user: 'user' }
+      },
+      request = new Request({}, options);
+
+    should(request.status).eql(666);
+    should(request.result).be.exactly(result);
+    should(request.error).be.instanceOf(KuzzleError);
+    should(request.error.message).be.exactly(error.message);
+    should(request.error.stack).be.exactly(error.stack);
+    should(request.error.status).be.exactly(request.error.status);
     should(request.context.protocol).eql('protocol');
     should(request.context.connectionId).eql('connectionId');
     should(request.context.token).match({token: 'token'});


### PR DESCRIPTION
# Description

When instanciating a new `Request` object from serialized data, and if an error object is present, then the request constructor throws the following error: `cannot set a non-error object as a request's error`

This PR fixes this problem by instanciating a new `KuzzleError` object prior to setting the error part of the request, when a serialized error has been provided.

# Boyscout

* Update error objects to ES6 classes

# Fixed issue

#59
