### PR TITLE
Generate an internal identifier when creating a request object instance

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -11,6 +11,7 @@ const
 
 // private properties
 const
+  _internalId = Symbol(),
   _status = Symbol(),
   _input = Symbol(),
   _error = Symbol(),
@@ -28,11 +29,31 @@ const
  *
  * Any undefined option is set to null
  *
+ * Differences between request.id and request.internalId: 
+ * 
+ * - the internal ID is meant to be unique, immutable, and the real 
+ *   identifier of a request object instance. It has a getter but
+ *   no setter, and is generated once and for all during a Request
+ *   object instantiation
+ * - the id (aka requestId) is an identifier that can be provided
+ *   to the constructor, allowing a client to set it in order to
+ *   listen for the related response afterwards. This property
+ *   is mutable and clients/plugins are free to use any value
+ *   for it
+ *
+ * In order to prevent any manipulation of Kuzzle's core components,
+ * the internalId is used to identify a request by Kuzzle, and
+ * the requestId should only be used by clients or plugins.
+ * 
  * @class
  * @param {Object} data - raw request content
  * @param {Object} [options]
  */
 
+/**
+ * @name  Request#internalId
+ * @type {string}
+ */
 /**
  * @name Request#timestamp
  * @type {number}
@@ -67,6 +88,7 @@ const
  */
 class Request {
   constructor(data, options) {
+    this[_internalId] = uuid.v4();
     this[_status] = 102;
     this[_input] = new RequestInput(data);
     this[_error] = null;
@@ -119,6 +141,14 @@ class Request {
     }
 
     Object.seal(this);
+  }
+
+  /** 
+   * Request internal identifier getter
+   * @return {string} 
+   */
+  get internalId () {
+    return this[_internalId];
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -3,17 +3,17 @@
   "description": "Common objects shared to various Kuzzle components and plugins",
   "main": "./index.js",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "dependencies": {
-    "uuid": "^3.0.0"
+    "uuid": "^3.2.1"
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "codecov": "^1.0.1",
-    "eslint": "3.10.2",
+    "codecov": "^3.0.0",
+    "eslint": "4.16.0",
     "istanbul": "^0.4.5",
-    "mocha": "^3.0.2",
-    "should": "^11.1.0"
+    "mocha": "^5.0.0",
+    "should": "^13.2.1"
   },
   "scripts": {
     "test": "npm run --silent lint && npm run unit-testing --coverage",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,6 +1,5 @@
 --bail
 --reporter spec
 --recursive
---no-exit
 --slow 2000
 --timeout 10000

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -99,7 +99,7 @@ describe('#Request', () => {
     should(rq.error).be.exactly(foo);
     should(rq.status).eql(666);
 
-    should(rq.error.toJSON()).match(foo);
+    should(rq.error.toJSON()).match({status: foo.status, message: foo.message});
   });
 
   it('should wrap a plain Error object into an InternalError one', () => {


### PR DESCRIPTION
# Description 
Currently, `Request` object instances can only be identified using the `requestId` field, a mutable property that can be set by plugins or clients.
Since this is the only available identifier, this can lead to vulnerabilities, for instance in the overload-protection mechanism, where the request identifier is key to manage the requests available slots.

This PR adds a new immutable `internalId` generated by the request constructor, usable by Kuzzle to safely identify a request object internally.

# Boyscout

Update dependencies.