### PR TITLE
Add default headers value to empty object for RequestInput

### DIFF
--- a/lib/models/requestInput.js
+++ b/lib/models/requestInput.js
@@ -134,7 +134,7 @@ class RequestInput {
     // initialize `_headers` property after the population of `this.args` attribute
     // `this.headers` can contain protocol specific headers and should be set after the Request construction
     // `args.headers` can be an attribute coming from data itself.
-    this[_headers] = null;
+    this[_headers] = {};
 
     Object.seal(this);
 
@@ -220,7 +220,7 @@ class RequestInput {
 
   /**
    * Request headers getter
-   * @returns {null|object}
+   * @returns {object}
    */
   get headers () {
     return this[_headers];
@@ -228,7 +228,7 @@ class RequestInput {
 
   /**
    * Request headers setter
-   * @param {null|object} obj - new request headers
+   * @param {object} obj - new request headers
    */
   set headers (obj) {
     this[_headers] = assert.assertObject('headers', obj);

--- a/test/models/requestInput.test.js
+++ b/test/models/requestInput.test.js
@@ -17,7 +17,7 @@ describe('#RequestInput', () => {
     should(input.resource._id).be.null();
     should(input.args).be.an.Object().and.be.empty();
     should(input.jwt).be.null();
-    should(input.headers).be.null();
+    should(input.headers).be.an.Object().and.be.empty();
   });
 
   it('should dispatch data correctly across properties', () => {


### PR DESCRIPTION
## What does this PR do ?

This PR add default headers to RequestInput.
The default headers are an empty object.  

Fix https://github.com/kuzzleio/kuzzle/issues/1067