### PR TITLE
Fix Request serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 .idea
 *.log
+.nyc_output

--- a/README.md
+++ b/README.md
@@ -60,9 +60,8 @@ This constructor is used to transform an [API request](http://kuzzle.io/api-refe
 
 | Name | Type | Description                      |
 |------|------|----------------------------------|
-| `connectionId` | `string` | Passed to [RequestContext](#modelsrequestcontext) constructor |
+| `connection` | `object` | Passed to [RequestContext](#modelsrequestcontext) constructor |
 | `error` | `KuzzleError` or `Error` | Invokes [setError](#seterrorerror) at initialization |
-| `protocol` | `string` | Passed to [RequestContext](#modelsrequestcontext) constructor |
 | `requestId` | `string` | Initializes the `id` property |
 | `result` | *(varies)* | Invokes [setResult](#setresultresult-options--null) at initialization |
 | `status` | `integer` | HTTP error code |
@@ -155,7 +154,7 @@ The `options` argument may contain the following properties:
 const Request = require('kuzzle-common-objects').Request;
 
 let request = new Request({
-  controller: 'write',
+  controller: 'document',
   action: 'create',
   index: 'foo',
   collection: 'bar',
@@ -175,24 +174,32 @@ console.dir(request.serialize(), {depth: null});
 Result:
 
 ```
-{ data:
-   { timestamp: 1482143102957,
-     requestId: '26d4ec6d-aafb-4ef8-951d-47666e5cf3ba',
-     jwt: null,
-     volatile: { some: 'volatile data' },
-     body: { document: 'content' },
-     controller: 'write',
-     action: 'create',
-     index: 'foo',
-     collection: 'bar',
-     _id: 'some document ID',
-     foo: 'bar' },
-  options:
-   { connectionId: null,
-     protocol: null,
-     result: null,
-     error: null,
-     status: 102 } }
+{ 
+  data: { 
+    timestamp: 1482143102957,
+    requestId: '26d4ec6d-aafb-4ef8-951d-47666e5cf3ba',
+    jwt: null,
+    volatile: { some: 'volatile data' },
+    body: { document: 'content' },
+    controller: 'document',
+    action: 'create',
+    index: 'foo',
+    collection: 'bar',
+    _id: 'some document ID',
+    foo: 'bar' 
+  },
+  options: { 
+    connection: {
+      id: null,
+      protocol: null,
+      ips: [],
+      misc: {}
+    },
+   result: null,
+   error: null,
+   status: 102 
+  } 
+}
 ```
 
 ## `RequestResponse`
@@ -207,7 +214,7 @@ Header names are case insensitive.
 **Example**
 
 ```
-if (request.context.protocol === 'http') {
+if (request.context.connection.protocol === 'http') {
   request.response.setHeader('Content-Type', 'text/plain');
 }
 ```
@@ -317,7 +324,7 @@ This constructor is used to create a connection context used by `Request`.
 | `id` | `string` | Connection unique identifier |
 | `protocol` | `string` | Protocol name (e.g. 'http', 'websocket', 'mqtt', ...) |
 | `ips` | `array` | Array of known IP addresses for the connection |
-| `misc` | `object` | Contain additional connection properties, depending on the connection's protocol used |
+| `misc` | `object` | Contain additional connection properties, depending on the connection's protocol used (for instance, input HTTP headers) |
 
 ## `models.RequestInput`
 

--- a/lib/models/requestContext.js
+++ b/lib/models/requestContext.js
@@ -131,7 +131,7 @@ class RequestContext {
     this.token = options.token;
     this.user = options.user;
 
-    // retro-compatibility
+    // @deprecated - backward compatibility only
     this.connectionId = options.connectionId;
     this.protocol = options.protocol;
   }

--- a/lib/models/requestInput.js
+++ b/lib/models/requestInput.js
@@ -131,8 +131,10 @@ class RequestInput {
       }
     });
 
+    // @deprecated - RequestContext.connection.misc.headers should be used instead
     // initialize `_headers` property after the population of `this.args` attribute
-    // `this.headers` can contain protocol specific headers and should be set after the Request construction
+    // `this.headers` can contain protocol specific headers and should be
+    // set after the Request construction
     // `args.headers` can be an attribute coming from data itself.
     this[_headers] = null;
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -29,9 +29,9 @@ const
  *
  * Any undefined option is set to null
  *
- * Differences between request.id and request.internalId: 
- * 
- * - the internal ID is meant to be unique, immutable, and the real 
+ * Differences between request.id and request.internalId:
+ *
+ * - the internal ID is meant to be unique, immutable, and the real
  *   identifier of a request object instance. It has a getter but
  *   no setter, and is generated once and for all during a Request
  *   object instantiation
@@ -44,7 +44,7 @@ const
  * In order to prevent any manipulation of Kuzzle's core components,
  * the internalId is used to identify a request by Kuzzle, and
  * the requestId should only be used by clients or plugins.
- * 
+ *
  * @class
  * @param {Object} data - raw request content
  * @param {Object} [options]
@@ -91,11 +91,14 @@ class Request {
     this[_internalId] = uuid.v4();
     this[_status] = 102;
     this[_input] = new RequestInput(data);
+    this[_context] = new RequestContext(options);
     this[_error] = null;
     this[_responseHeaders] = {};
     this[_result] = null;
-    this[_context] = new RequestContext(options);
     this[_response] = null;
+
+    // @deprecated - Backward compatibility with the RequestInput.headers property
+    this[_input].headers = this[_context].connection.misc.headers;
 
     this.id = data.requestId ? assert.assertString('requestId', data.requestId) : uuid.v4();
     this[_timestamp] = data.timestamp || Date.now();
@@ -143,9 +146,9 @@ class Request {
     Object.seal(this);
   }
 
-  /** 
+  /**
    * Request internal identifier getter
-   * @return {string} 
+   * @return {string}
    */
   get internalId () {
     return this[_internalId];
@@ -287,7 +290,7 @@ class Request {
    * @memberOf Request
    */
   serialize() {
-    let serialized = {
+    const serialized = {
       data: {
         timestamp: this[_timestamp],
         requestId: this.id,
@@ -301,16 +304,16 @@ class Request {
         _id: this[_input].resource._id,
       },
       options: {
-        connectionId: this[_context].connectionId,
-        protocol: this[_context].protocol,
         result: this[_result],
         error: this[_error],
         status: this[_status]
       },
+      // @deprecated - duplicate of options.connection.misc.headers
       headers: this[_input].headers
     };
 
     Object.assign(serialized.data, this[_input].args);
+    Object.assign(serialized.options, this[_context].toJSON());
 
     return serialized;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-common-objects",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Common objects shared to various Kuzzle components and plugins",
   "main": "./index.js",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "dependencies": {
     "uuid": "^3.3.2"
   },

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -216,18 +216,22 @@ describe('#Request', () => {
         volatile: {
           some: 'meta'
         },
-        foo: 'bar',
-        headers: {foo: 'args.header'}
+        foo: 'bar'
       },
       options = {
         status: 666,
-        connectionId: 'connectionId',
-        protocol: 'protocol'
+        connection: {
+          id: 'connectionId',
+          protocol: 'protocol',
+          url: 'url',
+          foobar: 'barfoo',
+          ips: ['i', 'p', 's'],
+          headers: {foo: 'args.headers'}
+        }
       },
       request = new Request(data, options),
       serialized;
 
-    request.input.headers = {foo: 'input.header'};
     request.setResult(result);
     request.setError(error);
 
@@ -235,7 +239,6 @@ describe('#Request', () => {
 
     should(serialized.data.body).match({some: 'body'});
     should(serialized.data.volatile).match({some: 'meta'});
-    should(serialized.data.headers).match({foo: 'args.header'});
     should(serialized.data.controller).be.eql('controller');
     should(serialized.data.action).be.eql('action');
     should(serialized.data.index).be.eql('idx');
@@ -244,15 +247,15 @@ describe('#Request', () => {
     should(serialized.data.timestamp).be.eql('timestamp');
     should(serialized.data.foo).be.eql('bar');
 
-    should(serialized.options.protocol).eql('protocol');
-    should(serialized.options.connectionId).be.eql('connectionId');
+    should(serialized.options.connection).match(options.connection);
+
     should(serialized.options.error).match(error);
     should(serialized.options.result).match(result);
     should(serialized.options.status).be.eql(500);
 
-    should(serialized.headers).match({foo: 'input.header'});
+    should(serialized.headers).match({foo: 'args.headers'});
 
-    let newRequest = new Request(serialized.data, serialized.options);
+    const newRequest = new Request(serialized.data, serialized.options);
     should(newRequest.response.toJSON()).match(request.response.toJSON());
     should(newRequest.timestamp).be.eql('timestamp');
   });


### PR DESCRIPTION
## What does this PR do ?

Changes introduced in the 3.0.8 version haven't impacted the serialization method, meaning that serializing/unserializing a `Request` object will not lead to the same content.

This PR fixes that. And since v3.0.8 should not be used in its current state, this PR should be a hotfix.

### How should this be manually tested?

```
const Request = require('kuzzle-common-objects).Request;

const foo = new Request({}, {
  connection: {
    id: 'foo', 
    protocol: 'bar', 
    url: '/foo/bar', 
    headers: {foo: 'bar'}, 
    ips: ['yolo']
  }
});

const serialized = foo.serialize();

const bar = new Request(serialized.data, serialized.options);

console.dir(foo.context.connection.toJSON(), {depth: null});
/*
  => prints:
  { user: null,
    token: null,
    connection: 
     { id: 'foo',
       protocol: 'bar',
       ips: [ 'yolo' ],
       url: '/foo/bar',
       headers: { foo: 'bar' } } }
*/


console.dir(bar.context.connection.toJSON(), {depth: null});
/*
  The output should be the same than the previous one, but in version 3.0.8 this prints:
  { connectionId: null, protocol: null, user: null, token: null }
 */
```
