### PR TITLE
add a deprecation jsdoc to the ParseError object

### DIFF
--- a/lib/errors/parseError.js
+++ b/lib/errors/parseError.js
@@ -1,5 +1,7 @@
 const KuzzleError = require('./kuzzleError');
-
+/**
+ * @deprecated since Kuzzle 1.4.1, BadRequestError should be used instead
+ */
 class ParseError extends KuzzleError {
   constructor (message) {
     super(message, 400);


### PR DESCRIPTION
## What does this PR do ?

This PR only adds a small jsdoc comment to the `ParseError` object, to remind us that it is deprecated (and since what Kuzzle version)