### PR TITLE
Hotfix: connection.id and connection.protocol should not be read-only

### DIFF
--- a/lib/models/requestContext.js
+++ b/lib/models/requestContext.js
@@ -53,9 +53,7 @@ class Connection {
   }
 
   set id(str) {
-    if (this[_c_id] === null) {
-      this[_c_id] = assert.assertString('connection.id', str);
-    }
+    this[_c_id] = assert.assertString('connection.id', str);
   }
 
   get id() {
@@ -63,9 +61,7 @@ class Connection {
   }
 
   set protocol(str) {
-    if (this[_c_protocol] === null) {
-      this[_c_protocol] = assert.assertString('connection.protocol', str);
-    }
+    this[_c_protocol] = assert.assertString('connection.protocol', str);
   }
 
   get protocol() {

--- a/lib/models/requestContext.js
+++ b/lib/models/requestContext.js
@@ -128,8 +128,13 @@ class RequestContext {
     this.user = options.user;
 
     // @deprecated - backward compatibility only
-    this.connectionId = options.connectionId;
-    this.protocol = options.protocol;
+    if (options.connectionId) {
+      this.connectionId = options.connectionId;
+    }
+
+    if (options.protocol) {
+      this.protocol = options.protocol;
+    }
   }
 
   toJSON() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-common-objects",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Common objects shared to various Kuzzle components and plugins",
   "main": "./index.js",
   "author": "The Kuzzle Team <support@kuzzle.io>",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "dependencies": {
     "uuid": "^3.3.2"
   },


### PR DESCRIPTION
## What does this PR do ?

The new `RequestContext` version has its `id` and `protocol` properties configured as "writable until a value has been set" (once set, those properties can never be changed).

While this is probably the best course of action regarding those 2 properties, this cause a backward-compatibility problem with pre-1.4.1 versions of Kuzzle, where a coding error in the HTTP embedded protocol first declare a RequestContext with a meaningless connection ID, and then with a connectionId update a bit later. Causing access logs to complain about non-existing connections.

### How should this be manually tested?

Start a Kuzzle pre-1.4.0 with the 3.0.9 version of this module. Submit any query, and the access log should complain about "a non-existing connection that might have been closed before the query had the chance to be executed" (or something like that)
