### PR TITLE
Add subcode error and explicit name to KuzzleError

### DIFF
--- a/lib/errors/badRequestError.js
+++ b/lib/errors/badRequestError.js
@@ -1,8 +1,8 @@
 const KuzzleError = require('./kuzzleError');
 
 class BadRequestError extends KuzzleError {
-  constructor(message) {
-    super(message, 400);
+  constructor(message, errorName, code) {
+    super(message, 400, errorName, code);
   }
 
   get name() {

--- a/lib/errors/externalServiceError.js
+++ b/lib/errors/externalServiceError.js
@@ -2,8 +2,8 @@ const KuzzleError = require('./kuzzleError');
 
 class ExternalServiceError extends KuzzleError {
   
-  constructor(message, code = '0000-0000') {
-    super(message, 500, code);
+  constructor(message, name = 'Undocumented error', code = 0) {
+    super(message, 500, name, code);
   }
   
   get name() {

--- a/lib/errors/externalServiceError.js
+++ b/lib/errors/externalServiceError.js
@@ -2,7 +2,7 @@ const KuzzleError = require('./kuzzleError');
 
 class ExternalServiceError extends KuzzleError {
   
-  constructor(message, errorName = 'Undocumented error', code = 0) {
+  constructor(message, errorName, code) {
     super(message, 500, errorName, code);
   }
   

--- a/lib/errors/externalServiceError.js
+++ b/lib/errors/externalServiceError.js
@@ -2,8 +2,8 @@ const KuzzleError = require('./kuzzleError');
 
 class ExternalServiceError extends KuzzleError {
   
-  constructor(message, name = 'Undocumented error', code = 0) {
-    super(message, 500, name, code);
+  constructor(message, errorName = 'Undocumented error', code = 0) {
+    super(message, 500, errorName, code);
   }
   
   get name() {

--- a/lib/errors/externalServiceError.js
+++ b/lib/errors/externalServiceError.js
@@ -1,11 +1,11 @@
 const KuzzleError = require('./kuzzleError');
 
 class ExternalServiceError extends KuzzleError {
-  /*************************/
+  
   constructor(message, code = '0000-0000') {
     super(message, 500, code);
   }
-  /*************************/
+  
   get name() {
     return "ExternalServiceError";
   }

--- a/lib/errors/externalServiceError.js
+++ b/lib/errors/externalServiceError.js
@@ -1,12 +1,13 @@
 const KuzzleError = require('./kuzzleError');
 
 class ExternalServiceError extends KuzzleError {
-  constructor(message) {
-    super(message, 500);
+  /*************************/
+  constructor(message, code = '0000-0000') {
+    super(message, 500, code);
   }
-
-  get name () {
-    return 'ExternalServiceError';
+  /*************************/
+  get name() {
+    return "ExternalServiceError";
   }
 }
 

--- a/lib/errors/externalServiceError.js
+++ b/lib/errors/externalServiceError.js
@@ -7,7 +7,7 @@ class ExternalServiceError extends KuzzleError {
   }
   
   get name() {
-    return "ExternalServiceError";
+    return 'ExternalServiceError';
   }
 }
 

--- a/lib/errors/forbiddenError.js
+++ b/lib/errors/forbiddenError.js
@@ -1,8 +1,8 @@
 const KuzzleError = require('./kuzzleError');
 
 class ForbiddenError extends KuzzleError {
-  constructor (message) {
-    super(message, 403);
+  constructor(message, errorName, code) {
+    super(message, 403, errorName, code);
   }
 
   get name () {

--- a/lib/errors/gatewayTimeoutError.js
+++ b/lib/errors/gatewayTimeoutError.js
@@ -1,8 +1,8 @@
 const KuzzleError = require('./kuzzleError');
 
 class GatewayTimeoutError extends KuzzleError {
-  constructor (message) {
-    super(message, 504);
+  constructor(message, errorName, code) {
+    super(message, 504, errorName, code);
   }
 
   get name () {

--- a/lib/errors/internalError.js
+++ b/lib/errors/internalError.js
@@ -1,8 +1,8 @@
 const KuzzleError = require('./kuzzleError');
 
 class InternalError extends KuzzleError {
-  constructor (message) {
-    super(message, 500);
+  constructor(message, errorName, code) {
+    super(message, 500, errorName, code);
   }
 
   get name () {

--- a/lib/errors/kuzzleError.js
+++ b/lib/errors/kuzzleError.js
@@ -34,7 +34,7 @@ class KuzzleError extends Error {
       status: this.status,
       stack: this.stack,
       code: this.code,
-      errorName: this.errorName
+      name: this.name
     };
   }
 }

--- a/lib/errors/kuzzleError.js
+++ b/lib/errors/kuzzleError.js
@@ -7,13 +7,13 @@ const util = require('util');
  */
 class KuzzleError extends Error {
 
-  constructor(message, status, name = 'Undocumented error', code = 0) {
+  constructor(message, status, errorName = 'Undocumented error', code = 0) {
     super(message);
 
     this.status = status;
 
     this.code = code;
-    this.name = name;
+    this.errorName = errorName;
 
     if (util.isError(message)) {
       this.message = message.message;
@@ -34,7 +34,7 @@ class KuzzleError extends Error {
       status: this.status,
       stack: this.stack,
       code: this.code,
-      name: this.name
+      errorName: this.errorName
     };
   }
 }

--- a/lib/errors/kuzzleError.js
+++ b/lib/errors/kuzzleError.js
@@ -13,7 +13,7 @@ class KuzzleError extends Error {
     this.status = status;
 
     this.code = code;
-    this.errorName = errorName;
+    this.name = name;
 
     if (util.isError(message)) {
       this.message = message.message;

--- a/lib/errors/kuzzleError.js
+++ b/lib/errors/kuzzleError.js
@@ -7,7 +7,7 @@ const util = require('util');
  */
 class KuzzleError extends Error {
 
-  constructor(message, status, errorName = 'Undocumented error', code = 0) {
+  constructor(message, status, name = 'Undocumented error', code = 0) {
     super(message);
 
     this.status = status;

--- a/lib/errors/kuzzleError.js
+++ b/lib/errors/kuzzleError.js
@@ -6,15 +6,13 @@ const util = require('util');
  * @constructor
  */
 class KuzzleError extends Error {
-  /*************************/
+
   constructor (message, status, code = '0000-0000') {
     super(message);
 
     this.status = status;
 
-    /*************************/
     this.errorCode = code;
-    /*************************/
 
     if (util.isError(message)) {
       this.message = message.message;
@@ -34,9 +32,7 @@ class KuzzleError extends Error {
       message: this.message,
       status: this.status,
       stack: this.stack,
-    /*************************/
       code: this.code
-    /*************************/
     };
   }
 }

--- a/lib/errors/kuzzleError.js
+++ b/lib/errors/kuzzleError.js
@@ -6,10 +6,15 @@ const util = require('util');
  * @constructor
  */
 class KuzzleError extends Error {
-  constructor (message, status) {
+  /*************************/
+  constructor (message, status, code = '0000-0000') {
     super(message);
 
     this.status = status;
+
+    /*************************/
+    this.errorCode = code;
+    /*************************/
 
     if (util.isError(message)) {
       this.message = message.message;
@@ -28,7 +33,10 @@ class KuzzleError extends Error {
     return {
       message: this.message,
       status: this.status,
-      stack: this.stack
+      stack: this.stack,
+    /*************************/
+      code: this.code
+    /*************************/
     };
   }
 }

--- a/lib/errors/kuzzleError.js
+++ b/lib/errors/kuzzleError.js
@@ -7,13 +7,13 @@ const util = require('util');
  */
 class KuzzleError extends Error {
 
-  constructor(message, status, name = 'Undocumented error', code = 0) {
+  constructor(message, status, errorName = 'Undocumented error', code = 0) {
     super(message);
 
     this.status = status;
 
     this.code = code;
-    this.name = name;
+    this.errorName = errorNname;
 
     if (util.isError(message)) {
       this.message = message.message;
@@ -34,7 +34,7 @@ class KuzzleError extends Error {
       status: this.status,
       stack: this.stack,
       code: this.code,
-      name: this.name
+      errorName: this.errorName
     };
   }
 }

--- a/lib/errors/kuzzleError.js
+++ b/lib/errors/kuzzleError.js
@@ -7,12 +7,13 @@ const util = require('util');
  */
 class KuzzleError extends Error {
 
-  constructor (message, status, code = '0000-0000') {
+  constructor(message, status, name = 'Undocumented error', code = 0) {
     super(message);
 
     this.status = status;
 
-    this.errorCode = code;
+    this.code = code;
+    this.name = name;
 
     if (util.isError(message)) {
       this.message = message.message;
@@ -32,7 +33,8 @@ class KuzzleError extends Error {
       message: this.message,
       status: this.status,
       stack: this.stack,
-      code: this.code
+      code: this.code,
+      name: this.name
     };
   }
 }

--- a/lib/errors/kuzzleError.js
+++ b/lib/errors/kuzzleError.js
@@ -13,7 +13,7 @@ class KuzzleError extends Error {
     this.status = status;
 
     this.code = code;
-    this.errorName = errorNname;
+    this.errorName = errorName;
 
     if (util.isError(message)) {
       this.message = message.message;

--- a/lib/errors/notFoundError.js
+++ b/lib/errors/notFoundError.js
@@ -1,8 +1,8 @@
 const KuzzleError = require('./kuzzleError');
 
 class NotFoundError extends KuzzleError {
-  constructor (message) {
-    super(message, 404);
+  constructor(message, errorName, code) {
+    super(message, 404, errorName, code);
   }
 
   get name () {

--- a/lib/errors/parseError.js
+++ b/lib/errors/parseError.js
@@ -3,7 +3,7 @@ const KuzzleError = require('./kuzzleError');
  * @deprecated since Kuzzle 1.4.1, BadRequestError should be used instead
  */
 class ParseError extends KuzzleError {
-  constructor (message) {
+  constructor(message, errorName, code) {
     super(message, 400);
   }
 

--- a/lib/errors/parseError.js
+++ b/lib/errors/parseError.js
@@ -4,7 +4,7 @@ const KuzzleError = require('./kuzzleError');
  */
 class ParseError extends KuzzleError {
   constructor(message, errorName, code) {
-    super(message, 400);
+    super(message, 400, errorName, code);
   }
 
   get name () {

--- a/lib/errors/partialError.js
+++ b/lib/errors/partialError.js
@@ -1,8 +1,8 @@
 const KuzzleError = require('./kuzzleError');
 
 class PartialError extends KuzzleError {
-  constructor (message, body = []) {
-    super(message, 206);
+  constructor(message, body = [], errorName, code) {
+    super(message, 206, errorName, code);
 
     this.errors = body;
     this.count = body.length;

--- a/lib/errors/partialError.js
+++ b/lib/errors/partialError.js
@@ -18,7 +18,9 @@ class PartialError extends KuzzleError {
       status: this.status,
       stack: this.stack,
       errors: this.errors,
-      count: this.count
+      count: this.count,
+      code: this.code,
+      errorName: this.errorName
     };
   }
 }

--- a/lib/errors/pluginImplementationError.js
+++ b/lib/errors/pluginImplementationError.js
@@ -1,8 +1,8 @@
 const KuzzleError = require('./kuzzleError');
 
 class PluginImplementationError extends KuzzleError {
-  constructor (message) {
-    super(message, 500);
+  constructor(message, errorName, code) {
+    super(message, 500, errorName, code);
     this.message += '\nThis is probably not a Kuzzle error, but a problem with a plugin implementation.';
   }
 

--- a/lib/errors/preconditionError.js
+++ b/lib/errors/preconditionError.js
@@ -1,8 +1,8 @@
 const KuzzleError = require('./kuzzleError');
 
 class PreconditionError extends KuzzleError {
-  constructor (message) {
-    super(message, 412);
+  constructor(message, errorName, code) {
+    super(message, 412, errorName, code);
   }
 
   get name () {

--- a/lib/errors/serviceUnavailableError.js
+++ b/lib/errors/serviceUnavailableError.js
@@ -1,8 +1,8 @@
 const KuzzleError = require('./kuzzleError');
 
 class ServiceUnavailable extends KuzzleError {
-  constructor (message) {
-    super(message, 503);
+  constructor(message, errorName, code) {
+    super(message, 503, errorName, code);
   }
 
   get name () {

--- a/lib/errors/sizeLimitError.js
+++ b/lib/errors/sizeLimitError.js
@@ -1,8 +1,8 @@
 const KuzzleError = require('./kuzzleError');
 
 class SizeLimitError extends KuzzleError {
-  constructor (message) {
-    super(message, 413);
+  constructor(message, errorName, code) {
+    super(message, 413, errorName, code);
   }
 
   get name () {

--- a/lib/errors/unauthorizedError.js
+++ b/lib/errors/unauthorizedError.js
@@ -1,8 +1,8 @@
 const KuzzleError = require('./kuzzleError');
 
 class UnauthorizedError extends KuzzleError {
-  constructor (message) {
-    super(message, 401);
+  constructor(message, errorName, code) {
+    super(message, 401, errorName, code);
   }
 
   get name () {


### PR DESCRIPTION
## What does this PR do ?

https://jira.kaliop.net/browse/KZL-1035

This PR is related to this [one](https://github.com/kuzzleio/kuzzle/pull/1306)
:exclamation: Do not merge until the previous one is.

It adds an explicit `name` and error `code` to `KuzzleError`

### How should this be manually tested?

clone the `kuzzle` repo and go to the `KZL-1035-subcode-error` branch
install this version of `kuzzle-common-objects` module
`npm install git://github.com/kuzzleio/kuzzle-common-objects.git#KZL-1035-subcode-error --save`
Run unit tests
`npm run unit-testing`