### PR TITLE
Fix response headers

### DIFF
--- a/lib/models/requestResponse.js
+++ b/lib/models/requestResponse.js
@@ -306,5 +306,4 @@ class RequestResponse {
   }
 }
 
-// module.exports = {RequestResponse, Headers};
 module.exports = RequestResponse;

--- a/lib/models/requestResponse.js
+++ b/lib/models/requestResponse.js
@@ -133,12 +133,9 @@ class RequestResponse {
    * @param {string} name
    */
   getHeader (name) {
-    const key = Object.keys(this[_headers])
-      .find(k => k.toLowerCase() === name.toLowerCase());
+    assert.assertString('header name', name);
 
-    if (key) {
-      return this[_headers][key];
-    }
+    return this[_headers][name.toLowerCase()];
   }
 
   /**
@@ -146,24 +143,30 @@ class RequestResponse {
    * @param {string} name
    */
   removeHeader (name) {
-    Object.keys(this[_headers])
-      .filter(key => key.toLowerCase() === name.toLowerCase())
-      .forEach(key => delete this[_headers][key]);
+    assert.assertString('header name', name);
+
+    delete this[_headers][name.toLowerCase()];
   }
 
   /**
-   * Set a new array. Behaves the same as [Node HTTP response.setHeader method](https://nodejs.org/api/http.html#http_response_setheader_name_value)
+   * Set a new array. Behaves the same as Node.js' HTTP response.setHeader
+   * method (@see https://nodejs.org/api/http.html#http_response_setheader_name_value)
    * @param {string} name
-   * @param {string} value
+   * @param {*} value
    */
   setHeader (name, value) {
     assert.assertString('header name', name);
-    assert.assertString('header value', value);
 
-    const lowercased = name.toLowerCase();
+    if (!name) {
+      return;
+    }
+
+    const
+      _name = name.toLowerCase(),
+      _value = String(value);
 
     // Handles specific HTTP headers
-    switch (lowercased) {
+    switch (_name) {
       case 'age':
       case 'authorization':
       case 'content-length':
@@ -180,22 +183,22 @@ class RequestResponse {
       case 'referer':
       case 'retry-after':
       case 'user-agent':
-        this[_headers][name] = value;
+        this[_headers][_name] = _value;
         break;
       case 'set-cookie':
-        if (!this[_headers][name]) {
-          this[_headers][name] = [value];
+        if (!this[_headers][_name]) {
+          this[_headers][_name] = [_value];
         }
         else {
-          this[_headers][name].push(value);
+          this[_headers][_name].push(_value);
         }
         break;
       default: {
-        if (this[_headers][name]) {
-          this[_headers][name] += ', ' + value;
+        if (this[_headers][_name]) {
+          this[_headers][_name] += ', ' + _value;
         }
         else {
-          this[_headers][name] = value;
+          this[_headers][_name] = _value;
         }
       }
     }
@@ -203,18 +206,15 @@ class RequestResponse {
   }
 
   /**
-   * **Add** new multiple headers
+   * Add new multiple headers.
    * @param {object} headers
    */
   setHeaders (headers) {
-    let hdrs = assert.assertUniTypeObject('headers', headers, 'string');
+    assert.assertObject('headers', headers);
 
-    if (hdrs === null) {
-      return;
+    if (headers) {
+      Object.keys(headers).forEach(name => this.setHeader(name, headers[name]));
     }
-
-    Object.keys(hdrs)
-      .forEach(name => this.setHeader(name, hdrs[name]));
   }
 
   /**

--- a/lib/models/requestResponse.js
+++ b/lib/models/requestResponse.js
@@ -213,7 +213,6 @@ class RequestResponse {
    */
   get headers () {
     return this[_headers].proxy;
-    // return this[_headers];
   }
 
   /**

--- a/lib/models/requestResponse.js
+++ b/lib/models/requestResponse.js
@@ -1,11 +1,37 @@
 'use strict';
 
 const
-  assert = require('../utils/assertType');
+  assert = require('../utils/assertType'),
+  BadRequestError = require('../errors/badRequestError');
 
 const
   _request = 'request\u200b',
   _headers = 'headers\u200b';
+
+/**
+ * Gets the case-sensitive version of property name "name" stored in the
+ * object "obj",
+ *
+ * Returns undefined if not found.
+ *
+ * @param  {object} obj
+ * @param  {string} name
+ * @return {string|undefined}
+ */
+function getStoredName(obj, name) {
+  if (!name) {
+    return;
+  }
+
+  const keys = Object.keys(obj)
+    .filter(key => key.toLowerCase() === name.toLowerCase());
+
+  if (keys.length > 1) {
+    throw new BadRequestError(`Duplicate headers: ${keys}`);
+  }
+
+  return keys[0];
+}
 
 /**
  * Kuzzle normalized response
@@ -135,7 +161,11 @@ class RequestResponse {
   getHeader (name) {
     assert.assertString('header name', name);
 
-    return this[_headers][name.toLowerCase()];
+    const storedName = getStoredName(this[_headers], name);
+
+    if (storedName) {
+      return this[_headers][storedName];
+    }
   }
 
   /**
@@ -145,7 +175,12 @@ class RequestResponse {
   removeHeader (name) {
     assert.assertString('header name', name);
 
-    delete this[_headers][name.toLowerCase()];
+
+    const storedName = getStoredName(this[_headers], name);
+
+    if (storedName) {
+      delete this[_headers][storedName];
+    }
   }
 
   /**
@@ -162,11 +197,11 @@ class RequestResponse {
     }
 
     const
-      _name = name.toLowerCase(),
+      _name = getStoredName(this[_headers], name) || name,
       _value = String(value);
 
     // Handles specific HTTP headers
-    switch (_name) {
+    switch (name.toLowerCase()) {
       case 'age':
       case 'authorization':
       case 'content-length':

--- a/lib/models/requestResponse.js
+++ b/lib/models/requestResponse.js
@@ -1,36 +1,114 @@
 'use strict';
 
-const
-  assert = require('../utils/assertType'),
-  BadRequestError = require('../errors/badRequestError');
+const assert = require('../utils/assertType');
 
 const
   _request = 'request\u200b',
   _headers = 'headers\u200b';
 
-/**
- * Gets the case-sensitive version of property name "name" stored in the
- * object "obj",
- *
- * Returns undefined if not found.
- *
- * @param  {object} obj
- * @param  {string} name
- * @return {string|undefined}
- */
-function getStoredName(obj, name) {
-  if (!name) {
-    return;
+class Headers {
+  constructor() {
+    this.namesMap = new Map();
+    this.headers = {};
+    this.proxy = new Proxy(this.headers, {
+      get: (target, name) => this.getHeader(name),
+      set: (target, name, value) => this.setHeader(name, value),
+      deleteProperty: (target, name) => this.removeHeader(name)
+    });
   }
 
-  const keys = Object.keys(obj)
-    .filter(key => key.toLowerCase() === name.toLowerCase());
+  getHeader (name) {
+    if (typeof name === 'symbol') {
+      return this.headers[name];
+    }
 
-  if (keys.length > 1) {
-    throw new BadRequestError(`Duplicate headers: ${keys}`);
+    assert.assertString(`"${name.toString()}"`, name);
+
+    if (!name) {
+      return;
+    }
+
+    return this.headers[this.namesMap.get(name.toLowerCase())];
   }
 
-  return keys[0];
+  removeHeader (name) {
+    assert.assertString(`"${name.toString()}"`, name);
+
+    if (!name) {
+      return true;
+    }
+
+    const
+      lowerCased = name.toLowerCase(),
+      storedName = this.namesMap.get(lowerCased);
+
+    if (storedName) {
+      delete this.headers[storedName];
+      this.namesMap.delete(lowerCased);
+    }
+
+    return true;
+  }
+
+  setHeader (name, value) {
+    assert.assertString(`"${name.toString()}"`, name);
+
+    if (!name) {
+      return true;
+    }
+
+    const
+      lowerCased = name.toLowerCase(),
+      _value = String(value);
+
+    let _name = this.namesMap.get(lowerCased);
+
+    if (!_name) {
+      this.namesMap.set(lowerCased, name);
+      _name = name;
+    }
+
+    // Common HTTP headers are overwritten when set, instead of being
+    // concatenated
+    switch (lowerCased) {
+      case 'age':
+      case 'authorization':
+      case 'content-length':
+      case 'content-type':
+      case 'etag':
+      case 'expires':
+      case 'from':
+      case 'host':
+      case 'if-modified-since':
+      case 'if-unmodified-since':
+      case 'last-modified, location':
+      case 'max-forwards':
+      case 'proxy-authorization':
+      case 'referer':
+      case 'retry-after':
+      case 'user-agent':
+        this.headers[_name] = _value;
+        break;
+      case 'set-cookie':
+        if (!this.headers[_name]) {
+          this.headers[_name] = [_value];
+        }
+        else {
+          this.headers[_name].push(_value);
+        }
+        break;
+      default: {
+        if (this.headers[_name]) {
+          this.headers[_name] += ', ' + _value;
+        }
+        else {
+          this.headers[_name] = _value;
+        }
+      }
+    }
+
+    return true;
+  }
 }
 
 /**
@@ -44,7 +122,7 @@ class RequestResponse {
   constructor (request) {
     this.raw = false;
     this[_request] = request;
-    this[_headers] = this[_request]['responseHeaders\u200b'];
+    this[_headers] = new Headers();
 
     Object.seal(this);
   }
@@ -134,7 +212,8 @@ class RequestResponse {
    * @returns {*}
    */
   get headers () {
-    return this[_headers];
+    return this[_headers].proxy;
+    // return this[_headers];
   }
 
   /**
@@ -159,13 +238,7 @@ class RequestResponse {
    * @param {string} name
    */
   getHeader (name) {
-    assert.assertString('header name', name);
-
-    const storedName = getStoredName(this[_headers], name);
-
-    if (storedName) {
-      return this[_headers][storedName];
-    }
+    return this[_headers].getHeader(name);
   }
 
   /**
@@ -173,14 +246,7 @@ class RequestResponse {
    * @param {string} name
    */
   removeHeader (name) {
-    assert.assertString('header name', name);
-
-
-    const storedName = getStoredName(this[_headers], name);
-
-    if (storedName) {
-      delete this[_headers][storedName];
-    }
+    return this[_headers].removeHeader(name);
   }
 
   /**
@@ -190,54 +256,7 @@ class RequestResponse {
    * @param {*} value
    */
   setHeader (name, value) {
-    assert.assertString('header name', name);
-
-    if (!name) {
-      return;
-    }
-
-    const
-      _name = getStoredName(this[_headers], name) || name,
-      _value = String(value);
-
-    // Handles specific HTTP headers
-    switch (name.toLowerCase()) {
-      case 'age':
-      case 'authorization':
-      case 'content-length':
-      case 'content-type':
-      case 'etag':
-      case 'expires':
-      case 'from':
-      case 'host':
-      case 'if-modified-since':
-      case 'if-unmodified-since':
-      case 'last-modified, location':
-      case 'max-forwards':
-      case 'proxy-authorization':
-      case 'referer':
-      case 'retry-after':
-      case 'user-agent':
-        this[_headers][_name] = _value;
-        break;
-      case 'set-cookie':
-        if (!this[_headers][_name]) {
-          this[_headers][_name] = [_value];
-        }
-        else {
-          this[_headers][_name].push(_value);
-        }
-        break;
-      default: {
-        if (this[_headers][_name]) {
-          this[_headers][_name] += ', ' + _value;
-        }
-        else {
-          this[_headers][_name] = _value;
-        }
-      }
-    }
-
+    return this[_headers].setHeader(name, value);
   }
 
   /**
@@ -287,4 +306,5 @@ class RequestResponse {
   }
 }
 
+// module.exports = {RequestResponse, Headers};
 module.exports = RequestResponse;

--- a/lib/models/requestResponse.js
+++ b/lib/models/requestResponse.js
@@ -22,7 +22,7 @@ class Headers {
       return this.headers[name];
     }
 
-    assert.assertString(`"${name.toString()}"`, name);
+    assert.assertString('header name', name);
 
     if (!name) {
       return;
@@ -32,7 +32,7 @@ class Headers {
   }
 
   removeHeader (name) {
-    assert.assertString(`"${name.toString()}"`, name);
+    assert.assertString('header name', name);
 
     if (!name) {
       return true;
@@ -51,7 +51,7 @@ class Headers {
   }
 
   setHeader (name, value) {
-    assert.assertString(`"${name.toString()}"`, name);
+    assert.assertString('header name', name);
 
     if (!name) {
       return true;

--- a/lib/request.js
+++ b/lib/request.js
@@ -16,7 +16,6 @@ const
   _status = 'status\u200b',
   _input = 'input\u200b',
   _error = 'error\u200b',
-  _responseHeaders = 'responseHeaders\u200b',
   _result = 'result\u200b',
   _context = 'context\u200b',
   _timestamp = 'timestamp\u200b',
@@ -94,11 +93,11 @@ class Request {
     this[_input] = new RequestInput(data);
     this[_context] = new RequestContext(options);
     this[_error] = null;
-    this[_responseHeaders] = {};
     this[_result] = null;
     this[_response] = null;
 
-    // @deprecated - Backward compatibility with the RequestInput.headers property
+    // @deprecated - Backward compatibility with the RequestInput.headers
+    // property
     this[_input].headers = this[_context].connection.misc.headers;
 
     this.id = data.requestId ? assert.assertString('requestId', data.requestId) : uuid.v4();

--- a/lib/utils/assertType.js
+++ b/lib/utils/assertType.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ParseError = require('../errors/parseError');
+const BadRequestError = require('../errors/badRequestError');
 
 /**
  * Throws if the provided data is not an object.
@@ -17,7 +17,7 @@ function assertObject(attr, data) {
   }
 
   if (typeof data !== 'object' || Array.isArray(data)) {
-    throw new ParseError(`Attribute ${attr} must be of type "object"`);
+    throw new BadRequestError(`Attribute ${attr} must be of type "object"`);
   }
 
   return data;
@@ -39,7 +39,7 @@ function assertArray(attr, data, type) {
   }
 
   if (!Array.isArray(data)) {
-    throw new ParseError(`Attribute ${attr} must be of type "array"`);
+    throw new BadRequestError(`Attribute ${attr} must be of type "array"`);
   }
 
   const clone = [];
@@ -47,7 +47,7 @@ function assertArray(attr, data, type) {
   for (const d of data) {
     if (d !== undefined && d !== null) {
       if (typeof d !== type) {
-        throw new ParseError(`Attribute ${attr} must contain only values of type "${type}"`);
+        throw new BadRequestError(`Attribute ${attr} must contain only values of type "${type}"`);
       }
 
       clone.push(d);
@@ -56,51 +56,6 @@ function assertArray(attr, data, type) {
 
   return clone;
 }
-
-/**
- * Throws if the provided object is not an object or if it contains heterogeaous typed properties.
- * Returns the unmodified data if validated.
- *
- * @throws {ParseError}
- * @param {string} attr - tested attribute name
- * @param {*} data
- * @param {string} [type] - expected type for data properties
- * @returns {object|null}
- */
-function assertUniTypeObject(attr, data, type) {
-  data = assertObject(attr, data);
-
-  if (data === null) {
-    return null;
-  }
-
-  Object.keys(data).forEach(key => {
-    if (type === undefined) {
-      type = typeof data[key];
-    }
-    type = type.toLowerCase();
-
-    let msg = `Attribute ${attr} must be of type "object" and have all its properties of type ${type}.`
-      + `\nExpected "${attr}.${key}" to be of type "${type}", but go "${typeof data[key]}".`;
-
-    switch (type) {
-      case 'array':
-        if (!Array.isArray(data[key])) {
-          throw new ParseError(msg);
-        }
-        break;
-      default:
-        if (typeof data[key] !== type) {
-          throw new ParseError(msg);
-        }
-        break;
-    }
-
-  });
-
-  return data;
-}
-
 
 /**
  * Throws if the provided data is not a string
@@ -117,7 +72,7 @@ function assertString(attr, data) {
   }
 
   if (typeof data !== 'string') {
-    throw new ParseError(`Attribute ${attr} must be of type "string"`);
+    throw new BadRequestError(`Attribute ${attr} must be of type "string"`);
   }
 
   return data;
@@ -134,14 +89,15 @@ function assertString(attr, data) {
  */
 function assertInteger(attr, data) {
   if (!Number.isInteger(data)) {
-    throw new ParseError(`Attribute ${attr} must be an integer`);
+    throw new BadRequestError(`Attribute ${attr} must be an integer`);
   }
 
   return data;
 }
 
-exports.assertObject = assertObject;
-exports.assertUniTypeObject = assertUniTypeObject;
-exports.assertString = assertString;
-exports.assertInteger = assertInteger;
-exports.assertArray = assertArray;
+module.exports = {
+  assertObject,
+  assertString,
+  assertInteger,
+  assertArray,
+};

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,5 @@
 --bail
---reporter spec
+--reporter dot
 --recursive
 --slow 2000
 --timeout 10000

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -199,13 +199,7 @@ describe('#Request', () => {
     should(response.index).eql(data.index);
     should(response.volatile).match(data.volatile);
     should(response.result).be.exactly(result);
-
-    const expectedHeaders = {};
-    for (const header of Object.keys(responseHeaders)) {
-      expectedHeaders[header.toLowerCase()] = responseHeaders[header];
-    }
-
-    should(response.headers).match(expectedHeaders);
+    should(response.headers).match(responseHeaders);
   });
 
   it('should serialize the request correctly', () => {

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -4,6 +4,7 @@ const
   should = require('should'),
   KuzzleError = require('../lib/errors/kuzzleError'),
   InternalError = require('../lib/errors/internalError'),
+  BadRequestError = require('../lib/errors/badRequestError'),
   Request = require('../lib/request'),
   RequestContext = require('../lib/models/requestContext'),
   RequestInput = require('../lib/models/requestInput');
@@ -146,10 +147,11 @@ describe('#Request', () => {
   });
 
   it('should throw if trying to set some non-object headers', () => {
-    should(() => { rq.setResult('foobar', {headers: 42}); }).throw('Attribute headers must be of type "object"');
-    should(() => { rq.setResult('foobar', {headers: { a: true }}); }).throw('Attribute headers must be of type "object" and have all its properties of type string.\nExpected "headers.a" to be of type "string", but go "boolean".');
-    should(() => { rq.setResult('foobar', {headers:  'bar'}); }).throw('Attribute headers must be of type "object"');
-    should(() => { rq.setResult('foobar', {headers:  true}); }).throw('Attribute headers must be of type "object"');
+    [ 42, [true, false], 'bar', true ].forEach(value => {
+      should(() => rq.setResult('foobar', {headers: value})).throw(
+        BadRequestError,
+        {message: 'Attribute headers must be of type "object"'});
+    });
   });
 
   it('should set the raw response indicator if provided', () => {
@@ -164,7 +166,7 @@ describe('#Request', () => {
   });
 
   it('should build a well-formed response', () => {
-    let
+    const
       result = {foo: 'bar'},
       responseHeaders = {
         'X-Foo': 'bar',
@@ -181,13 +183,12 @@ describe('#Request', () => {
           some: 'meta'
         }
       },
-      request = new Request(data),
-      response;
+      request = new Request(data);
 
     request.setResult(result, {status: 201, headers: responseHeaders});
     request.setError(error);
 
-    response = request.response;
+    const response = request.response;
 
     should(response.status).eql(500);
     should(response.error).be.exactly(error);
@@ -197,8 +198,14 @@ describe('#Request', () => {
     should(response.collection).eql(data.collection);
     should(response.index).eql(data.index);
     should(response.volatile).match(data.volatile);
-    should(response.headers).match(responseHeaders);
     should(response.result).be.exactly(result);
+
+    const expectedHeaders = {};
+    for (const header of Object.keys(responseHeaders)) {
+      expectedHeaders[header.toLowerCase()] = responseHeaders[header];
+    }
+
+    should(response.headers).match(expectedHeaders);
   });
 
   it('should serialize the request correctly', () => {

--- a/test/utils/assertType.test.js
+++ b/test/utils/assertType.test.js
@@ -1,33 +1,9 @@
 const
   should = require('should'),
   assert = require('../../lib/utils/assertType'),
-  ParseError = require('../../lib/errors/parseError');
+  BadRequestError = require('../../lib/errors/badRequestError');
 
 describe('#assertType', () => {
-  describe('#assertUnitTypeObject', () => {
-    it('should infer the type from the first property', () => {
-      should(() => {
-        assert.assertUniTypeObject('test', {
-          foo: ['bar'],
-          baz: true
-        });
-
-      }).throw(ParseError);
-    });
-
-    it('should detect object of arrays', () => {
-      const data = {
-        a: [1],
-        b: [2, 4],
-        c: 42,
-
-      };
-
-      should(() => assert.assertUniTypeObject('test', data, 'array'))
-        .throw(ParseError);
-    });
-  });
-
   describe('#assertArray', () => {
     it('should return an empty array if null/undefined is provided', () => {
       should(assert.assertArray('foo', null, 'string')).eql([]);
@@ -50,7 +26,7 @@ describe('#assertType', () => {
     it('should throw if the provided data is not an array', () => {
       for (const wrong of [{}, 'foo', 123, true, false]) {
         should(() => assert.assertArray('foo', wrong, 'string'))
-          .throw(ParseError, {message: 'Attribute foo must be of type "array"'});
+          .throw(BadRequestError, {message: 'Attribute foo must be of type "array"'});
       }
     });
 
@@ -58,7 +34,7 @@ describe('#assertType', () => {
       for (const wrong of [{}, [], 123, true, false]) {
         const arr = ['foo', wrong, 'bar'];
         should(() => assert.assertArray('foo', arr, 'string'))
-          .throw(ParseError, {message: 'Attribute foo must contain only values of type "string"'});
+          .throw(BadRequestError, {message: 'Attribute foo must contain only values of type "string"'});
       }
     });
   });


### PR DESCRIPTION
# Description

Fix several problems with how response headers are currently handled:

## Storage

Response headers are currently stored in the `Request` object, but can only be accessed from the `RequestResponse` one. 

This makes it impossible to create a standalone `RequestResponse` object, and I can see no reason to store response headers outside the RequestResponse object.

## Duplicates

Response headers are meant to be case-insensitive, while retaining the letter cases used when setting a value to a header.
This is because response headers are meant to be universal, and if HTTP headers are case insensitive, other protocols headers might not be. 

But the current implementation is done in such a way that simply setting the same header with different letter cases leads to duplicate headers. This is a mean bug, as Kuzzle itself sets some headers in its HTTP responses, and those can collide with headers set by plugins instead of overwritten them (e.g. `Content-Length`)

Also, the current way of checking duplicates is slow and ineffective performance-wise: a map is now used instead of a systematic scan of all stored headers.

## RequestResponse.headers property

The `headers` property of the RequestResponse object returns the reference of the underlying object storing headers. This is a problem because it allows anyone to bypass the custom getters and setters, making the duplicates handling difficult.

This is resolved by making that getter return a proxy to the headers object instead of the object itself.

## Headers values restriction

The current version of RequestResponse.setHeader only allows string values, but this is too restrictive. 
I decided instead to copy [Node.js' behavior](https://nodejs.org/api/http.html#http_response_setheader_name_value) and non-string values are automatically stringified.

# How to test

The simplest way would be, if you feel like it, to create a small plugin for Kuzzle's 1-dev branch, and make it respond with a content-length header using different letter cases than `Content-Length`.

With the current version of this common-objects library, you get a duplicated header. With this branch, Kuzzle will overwrite the value your plugin has set, while still retaining the same letter cases enforced by the plugin (since it set the header first).