### PR TITLE
Error codes support

### DIFF
--- a/lib/errors/badRequestError.js
+++ b/lib/errors/badRequestError.js
@@ -1,8 +1,8 @@
 const KuzzleError = require('./kuzzleError');
 
 class BadRequestError extends KuzzleError {
-  constructor(message, errorName, code) {
-    super(message, 400, errorName, code);
+  constructor(message, id, code) {
+    super(message, 400, id, code);
   }
 
   get name() {

--- a/lib/errors/externalServiceError.js
+++ b/lib/errors/externalServiceError.js
@@ -1,11 +1,11 @@
 const KuzzleError = require('./kuzzleError');
 
 class ExternalServiceError extends KuzzleError {
-  
-  constructor(message, errorName, code) {
-    super(message, 500, errorName, code);
+
+  constructor(message, id, code) {
+    super(message, 500, id, code);
   }
-  
+
   get name() {
     return 'ExternalServiceError';
   }

--- a/lib/errors/forbiddenError.js
+++ b/lib/errors/forbiddenError.js
@@ -1,8 +1,8 @@
 const KuzzleError = require('./kuzzleError');
 
 class ForbiddenError extends KuzzleError {
-  constructor(message, errorName, code) {
-    super(message, 403, errorName, code);
+  constructor(message, id, code) {
+    super(message, 403, id, code);
   }
 
   get name () {

--- a/lib/errors/gatewayTimeoutError.js
+++ b/lib/errors/gatewayTimeoutError.js
@@ -1,8 +1,8 @@
 const KuzzleError = require('./kuzzleError');
 
 class GatewayTimeoutError extends KuzzleError {
-  constructor(message, errorName, code) {
-    super(message, 504, errorName, code);
+  constructor(message, id, code) {
+    super(message, 504, id, code);
   }
 
   get name () {

--- a/lib/errors/internalError.js
+++ b/lib/errors/internalError.js
@@ -1,8 +1,8 @@
 const KuzzleError = require('./kuzzleError');
 
 class InternalError extends KuzzleError {
-  constructor(message, errorName, code) {
-    super(message, 500, errorName, code);
+  constructor(message, id, code) {
+    super(message, 500, id, code);
   }
 
   get name () {

--- a/lib/errors/kuzzleError.js
+++ b/lib/errors/kuzzleError.js
@@ -6,19 +6,18 @@ const util = require('util');
  * @constructor
  */
 class KuzzleError extends Error {
-
-  constructor(message, status, errorName = 'Undocumented error', code = 0) {
+  constructor(message, status = 500, id = null, code = -1) {
     super(message);
 
     this.status = status;
-
     this.code = code;
-    this.errorName = errorName;
+    this.id = id;
 
     if (util.isError(message)) {
       this.message = message.message;
       this.stack = message.stack;
-    } else {
+    }
+    else {
       this.message = message;
       Error.captureStackTrace(this, KuzzleError);
     }
@@ -28,12 +27,25 @@ class KuzzleError extends Error {
     return 'KuzzleError';
   }
 
+  // @deprecated use "id" instead
+  get errorName () {
+    return this.id;
+  }
+
   toJSON () {
-    return {
+    const json = {
       message: this.message,
       status: this.status,
       stack: this.stack
     };
+
+    // backward compatibility with older versions of kuzzle
+    if (this.id !== null && this.code !== -1) {
+      json.id = this.id;
+      json.code = this.code;
+    }
+
+    return json;
   }
 }
 

--- a/lib/errors/notFoundError.js
+++ b/lib/errors/notFoundError.js
@@ -1,8 +1,8 @@
 const KuzzleError = require('./kuzzleError');
 
 class NotFoundError extends KuzzleError {
-  constructor(message, errorName, code) {
-    super(message, 404, errorName, code);
+  constructor(message, id, code) {
+    super(message, 404, id, code);
   }
 
   get name () {

--- a/lib/errors/parseError.js
+++ b/lib/errors/parseError.js
@@ -3,8 +3,8 @@ const KuzzleError = require('./kuzzleError');
  * @deprecated since Kuzzle 1.4.1, BadRequestError should be used instead
  */
 class ParseError extends KuzzleError {
-  constructor(message, errorName, code) {
-    super(message, 400, errorName, code);
+  constructor(message, id, code) {
+    super(message, 400, id, code);
   }
 
   get name () {

--- a/lib/errors/partialError.js
+++ b/lib/errors/partialError.js
@@ -1,8 +1,17 @@
 const KuzzleError = require('./kuzzleError');
 
 class PartialError extends KuzzleError {
-  constructor(message, body = [], errorName, code) {
-    super(message, 206, errorName, code);
+  constructor(message, body, id, code) {
+    if (code === undefined && typeof id === 'number') {
+      code = id;
+      id = body;
+      body = [];
+    }
+    else if (body === undefined) {
+      body = [];
+    }
+
+    super(message, 206, id, code);
 
     this.errors = body;
     this.count = body.length;
@@ -13,13 +22,12 @@ class PartialError extends KuzzleError {
   }
 
   toJSON () {
-    return {
-      message: this.message,
-      status: this.status,
-      stack: this.stack,
-      errors: this.errors,
-      count: this.count
-    };
+    const serialized = super.toJSON();
+
+    serialized.errors = this.errors;
+    serialized.count = this.count;
+
+    return serialized;
   }
 }
 

--- a/lib/errors/pluginImplementationError.js
+++ b/lib/errors/pluginImplementationError.js
@@ -1,8 +1,8 @@
 const KuzzleError = require('./kuzzleError');
 
 class PluginImplementationError extends KuzzleError {
-  constructor(message, errorName, code) {
-    super(message, 500, errorName, code);
+  constructor(message, id, code) {
+    super(message, 500, id, code);
     this.message += '\nThis is probably not a Kuzzle error, but a problem with a plugin implementation.';
   }
 

--- a/lib/errors/preconditionError.js
+++ b/lib/errors/preconditionError.js
@@ -1,12 +1,12 @@
 const KuzzleError = require('./kuzzleError');
 
 class PreconditionError extends KuzzleError {
-  constructor(message, errorName, code) {
-    super(message, 412, errorName, code);
+  constructor(message, id, code) {
+    super(message, 412, id, code);
   }
 
   get name () {
-    return 'Precondition Failed';
+    return 'PreconditionError';
   }
 }
 

--- a/lib/errors/serviceUnavailableError.js
+++ b/lib/errors/serviceUnavailableError.js
@@ -1,8 +1,8 @@
 const KuzzleError = require('./kuzzleError');
 
 class ServiceUnavailable extends KuzzleError {
-  constructor(message, errorName, code) {
-    super(message, 503, errorName, code);
+  constructor(message, id, code) {
+    super(message, 503, id, code);
   }
 
   get name () {

--- a/lib/errors/sizeLimitError.js
+++ b/lib/errors/sizeLimitError.js
@@ -1,8 +1,8 @@
 const KuzzleError = require('./kuzzleError');
 
 class SizeLimitError extends KuzzleError {
-  constructor(message, errorName, code) {
-    super(message, 413, errorName, code);
+  constructor(message, id, code) {
+    super(message, 413, id, code);
   }
 
   get name () {

--- a/lib/errors/unauthorizedError.js
+++ b/lib/errors/unauthorizedError.js
@@ -1,20 +1,12 @@
 const KuzzleError = require('./kuzzleError');
 
 class UnauthorizedError extends KuzzleError {
-  constructor(message, errorName, code) {
-    super(message, 401, errorName, code);
+  constructor(message, id, code) {
+    super(message, 401, id, code);
   }
 
   get name () {
     return 'UnauthorizedError';
-  }
-
-  get subCodes () {
-    return {
-      TokenExpired: 1,
-      JsonWebTokenError: 2,
-      AuthenticationError: 3
-    };
   }
 }
 

--- a/test/errors/kuzzleError.test.js
+++ b/test/errors/kuzzleError.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const
+  should = require('should'),
+  KuzzleError = require('../../lib/errors/kuzzleError');
+
+describe('#ExternalServiceError', () => {
+  it('should create a well-formed object', () => {
+    const err = new KuzzleError('foobar');
+
+    should(err.message).be.eql('foobar');
+    should(err.status).be.eql(500);
+    should(err.name).be.eql('KuzzleError');
+    should(err.stack).be.a.String();
+  });
+
+  it('should derivate from a previous error', () => {
+    const
+      orig = new Error('foo'),
+      err = new KuzzleError(orig);
+
+    should(err.message).be.eql(orig.message);
+    should(err.status).be.eql(500);
+    should(err.name).be.eql('KuzzleError');
+    should(err.stack).be.eql(orig.stack);
+  });
+
+  it('should serialize correctly', () => {
+    const err = JSON.parse(JSON.stringify(new KuzzleError('foobar')));
+
+    should(err.message).be.eql('foobar');
+    should(err.status).be.eql(500);
+    should(err.code).be.undefined();
+    should(err.id).be.undefined();
+  });
+
+  it('should serialize the new error codes and ids', () => {
+    const
+      err = new KuzzleError('foobar', 500, 'ohnoes', 123),
+      serialized = JSON.parse(JSON.stringify(err));
+
+    should(serialized.message).be.eql('foobar');
+    should(serialized.status).be.eql(500);
+    should(serialized.code).be.eql(123);
+    should(serialized.id).be.eql('ohnoes');
+  });
+});


### PR DESCRIPTION
# Description

KuzzleError objects are now serialized with the error id and code.

Same changes than in https://github.com/kuzzleio/kuzzle-common-objects/pull/84 except that this version is backward compatible with ALL versions of Kuzzle v1.