### PR TITLE
Add a new TooManyRequestsError class (status 429)

### DIFF
--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -13,5 +13,5 @@ module.exports = {
   SizeLimitError: require('./sizeLimitError'),
   UnauthorizedError: require('./unauthorizedError'),
   PreconditionError: require('./preconditionError'),
-  TooManyRequestsError: require('./tooManyRequestsError');
+  TooManyRequestsError: require('./tooManyRequestsError')
 };

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -12,5 +12,6 @@ module.exports = {
   ServiceUnavailableError: require('./serviceUnavailableError'),
   SizeLimitError: require('./sizeLimitError'),
   UnauthorizedError: require('./unauthorizedError'),
-  PreconditionError: require('./preconditionError')
+  PreconditionError: require('./preconditionError'),
+  TooManyRequestsError: require('./tooManyRequestsError');
 };

--- a/lib/errors/tooManyRequestsError.js
+++ b/lib/errors/tooManyRequestsError.js
@@ -1,0 +1,13 @@
+const KuzzleError = require('./kuzzleError');
+
+class TooManyRequestsError extends KuzzleError {
+  constructor(message, id, code) {
+    super(message, 429, id, code);
+  }
+
+  get name() {
+    return 'TooManyRequestsError';
+  }
+}
+
+module.exports = TooManyRequestsError;


### PR DESCRIPTION
# Description

Add a `TooManyRequestsError` class (HTTP status: 429).

This class is meant to be used by the new rate-limit system that will be implemented in Kuzzle Core.