### PR TITLE
Add deprecation notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Common objects shared to various Kuzzle components and plugins.
       - [`setError(error)`](#seterrorerror)
       - [`clearError()`](#clearerror)
       - [`setResult(result, [options = null])`](#setresultresult-options--null)
+      - [`addDeprecation(version, message)`](#addDeprecationversion-message)
     - [Example](#example)
   - [`RequestResponse`](#requestresponse)
     - [Attributes](#attributes-1)
@@ -97,6 +98,7 @@ Please refer to our [API Reference](http://kuzzle.io/api-reference/?websocket) f
 | `input` | `RequestInput` | [RequestInput](#modelsrequestinput) object | Request's parameters |
 | `response` | `RequestResponse` | Response view of the request, standardized as the expected [Kuzzle API response](http://kuzzle.io/api-reference/?websocket#kuzzle-response) |
 | `result` | *(varies)* | `null` | Request result, if any |
+| `deprecations` | `object[]` | `undefined` | Deprecations, if any |
 
 ### Methods
 
@@ -202,6 +204,25 @@ Result:
 }
 ```
 
+#### `addDeprecation(version, message)`
+
+Adds a deprecation on the request object allowing to notify when a controller or an action is deprecated for a specific version of Kuzzle
+
+**Arguments**
+
+| Name | Type | Description                      |
+|------|------|----------------------------------|
+| `version` | `string` | target version of the deprecation |
+| `message` | `string` | description of the deprecation |
+
+**Example**
+
+```js
+let request = new Request({});
+request.addDeprecation('1.0.0', 'You should now use Kuzzle v2')
+console.log(request.deprecations) // [{ version: '1.0.0', 'You should now use Kuzzle v2' }]
+```
+
 ## `RequestResponse`
 
 This object is not exposed and can only be retrieved using the `Request.response` getter.
@@ -240,6 +261,7 @@ if (request.context.connection.protocol === 'http') {
 | `index` | `string` | Parent request data index |
 | `volatile` | `object` | Parent request volatile data |
 | `requestId` | `string` | Parent request unique identifier |
+| `deprecations` | `object[]` | Deprecations |
 
 ### Methods
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ Result:
 
 Adds a deprecation on the request object allowing to notify when a controller or an action is deprecated for a specific version of Kuzzle
 
+::: info
+Deprecation messages in request responses will only be added during development stages, i.e. if the `NODE_ENV` environment variable is set to `development`.
+:::
+
 **Arguments**
 
 | Name | Type | Description                      |

--- a/lib/models/requestResponse.js
+++ b/lib/models/requestResponse.js
@@ -137,10 +137,10 @@ class RequestResponse {
 
   /**
    * Set the parent request deprecations
-   * @param {Object[]} decrations
+   * @param {Object[]} deprecations
    */
-  set deprecations (decrations) {
-    this[_request].deprecations = decrations;
+  set deprecations (deprecations) {
+    this[_request].deprecations = deprecations;
   }
 
   /**

--- a/lib/models/requestResponse.js
+++ b/lib/models/requestResponse.js
@@ -128,6 +128,22 @@ class RequestResponse {
   }
 
   /**
+   * Get the parent request deprecations
+   * @returns {Object[]}
+   */
+  get deprecations () {
+    return this[_request].deprecations;
+  }
+
+  /**
+   * Set the parent request deprecations
+   * @param {Object[]} decrations
+   */
+  set deprecations (decrations) {
+    this[_request].deprecations = decrations;
+  }
+
+  /**
    * Get the parent request status
    * @returns {number}
    */
@@ -298,7 +314,8 @@ class RequestResponse {
         collection: this.collection,
         index: this.index,
         volatile: this.volatile,
-        result: this.result
+        result: this.result,
+        deprecations: this.deprecations,
       },
       headers: this.headers
     };

--- a/lib/request.js
+++ b/lib/request.js
@@ -153,19 +153,19 @@ class Request {
    * Request internal identifier getter
    * @return {Object[]}
    */
-  get deprecations () {
+  get deprecations() {
     return this[_deprecations];
   }
 
-  set deprecations (deprecations) {
-    this[_deprecations] = assert.assertArray('deprecations', deprecations, Object);
+  set deprecations(deprecations) {
+    this[_deprecations] = assert.assertArray('deprecations', deprecations, 'object');
   }
 
   /**
    * Request internal identifier getter
    * @return {string}
    */
-  get internalId () {
+  get internalId() {
     return this[_internalId];
   }
 
@@ -173,7 +173,7 @@ class Request {
    * Request timestamp getter
    * @returns {number}
    */
-  get timestamp () {
+  get timestamp() {
     return this[_timestamp];
   }
 
@@ -181,7 +181,7 @@ class Request {
    * Request status getter
    * @returns {number}
    */
-  get status () {
+  get status() {
     return this[_status];
   }
 
@@ -189,7 +189,7 @@ class Request {
    * Request status setter
    * @param {number} i - new request status
    */
-  set status (i) {
+  set status(i) {
     this[_status] = assert.assertInteger('status', i);
   }
 
@@ -197,7 +197,7 @@ class Request {
    * Request input getter
    * @returns {RequestInput}
    */
-  get input () {
+  get input() {
     return this[_input];
   }
 
@@ -205,7 +205,7 @@ class Request {
    * Request context getter
    * @returns {RequestContext}
    */
-  get context () {
+  get context() {
     return this[_context];
   }
 
@@ -213,7 +213,7 @@ class Request {
    * Request error getter
    * @returns {null|KuzzleError}
    */
-  get error () {
+  get error() {
     return this[_error];
   }
 
@@ -221,7 +221,7 @@ class Request {
    * Request result getter
    * @returns {null|*}
    */
-  get result () {
+  get result() {
     return this[_result];
   }
 
@@ -229,7 +229,7 @@ class Request {
    * Request response getter
    * @returns {{status: (number|*), error: (null|*), requestId: string, controller: string, action: string, collection: string, index: string, volatile: Object, headers: (Array|*), result: (null|*|Object)}}
    */
-  get response () {
+  get response() {
     if (this[_response] === null) {
       this[_response] = new RequestResponse(this);
     }
@@ -303,16 +303,18 @@ class Request {
    * @param {String} message message displayed in the warning
    */
   addDeprecation(version, message) {
-    if (!this.deprecations) {
-      this.deprecations = [];
-    }
-
     const deprecation = {
       version,
       message
     };
 
-    this.deprecations.push(deprecation);
+    if (!this.deprecations) {
+      this.deprecations = [deprecation];
+    } else {
+      this.deprecations.push(deprecation);
+    }
+
+
   }
 
   /**

--- a/lib/request.js
+++ b/lib/request.js
@@ -18,6 +18,7 @@ const _result = 'result\u200b';
 const _context = 'context\u200b';
 const _timestamp = 'timestamp\u200b';
 const _response = 'response\u200b';
+const _deprecations = 'deprecations\u200b';
 
 /**
  * Builds a Kuzzle normalized request object
@@ -93,6 +94,7 @@ class Request {
     this[_error] = null;
     this[_result] = null;
     this[_response] = null;
+    this[_deprecations] = undefined;
 
     // @deprecated - Backward compatibility with the RequestInput.headers
     // property
@@ -145,6 +147,18 @@ class Request {
     }
 
     Object.seal(this);
+  }
+
+  /**
+   * Request internal identifier getter
+   * @return {Object[]}
+   */
+  get deprecations () {
+    return this[_deprecations];
+  }
+
+  set deprecations (deprecations) {
+    this[_deprecations] = assert.assertArray('deprecations', deprecations, Object);
   }
 
   /**
@@ -280,6 +294,25 @@ class Request {
     }
 
     this[_result] = result;
+  }
+
+  /**
+   * Add a deprecation for a used component, this can be action/controller/parameters...
+   * 
+   * @param {String} version version where the used component has been deprecated
+   * @param {String} message message displayed in the warning
+   */
+  addDeprecation(version, message) {
+    if (!this.deprecations) {
+      this.deprecations = [];
+    }
+
+    const deprecation = {
+      version,
+      message
+    };
+
+    this.deprecations.push(deprecation);
   }
 
   /**

--- a/lib/request.js
+++ b/lib/request.js
@@ -303,6 +303,10 @@ class Request {
    * @param {String} message message displayed in the warning
    */
   addDeprecation(version, message) {
+    if (process.env.NODE_ENV !== 'development') {
+      return;
+    }
+
     const deprecation = {
       version,
       message

--- a/test/models/requestResponse.test.js
+++ b/test/models/requestResponse.test.js
@@ -32,6 +32,7 @@ describe('#RequestResponse', () => {
       should(response.volatile).be.exactly(req.input.volatile);
       should(response.headers).be.an.Object().and.be.empty();
       should(response.result).be.exactly(req.result);
+      should(response.deprecations).be.undefined();
     });
 
     it('should throw if we try to extend the response', () => {
@@ -278,7 +279,8 @@ describe('#RequestResponse', () => {
         'collection',
         'index',
         'volatile',
-        'result'
+        'result',
+        'deprecations'
       ]);
       should(response.toJSON().raw).be.false();
       should(response.toJSON().headers).match({'x-foo': 'bar'});

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -294,11 +294,19 @@ describe('#Request', () => {
     should(request.status).eql(200);
   });
 
-  it('should add a deprecation correctly', () => {
+  it('should add a deprecation when kuzzle is in development', () => {
+    process.env.NODE_ENV = 'development';
     rq.addDeprecation('1.0.0', 'You should now use Kuzzle v2');
 
     should(rq.deprecations).be.Array();
     should(rq.deprecations).be.lengthOf(1);
     should(rq.deprecations[0]).deepEqual({ version: '1.0.0', message: 'You should now use Kuzzle v2' });
+  });
+
+  it('should not add a deprecation when kuzzle is in production', () => {
+    process.env.NODE_ENV = 'production';
+    rq.addDeprecation('1.0.0', 'You should now use Kuzzle v2');
+
+    should(rq.deprecations).be.undefined();
   });
 });

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -22,11 +22,12 @@ describe('#Request', () => {
     should(rq.input).be.instanceOf(RequestInput);
     should(rq.result).be.null();
     should(rq.error).be.null();
+    should(rq.deprecations).be.undefined();
   });
 
   it('should initialize the request object with the provided options', () => {
     let
-      result = {foo: 'bar'},
+      result = { foo: 'bar' },
       error = new InternalError('foobar'),
       options = {
         status: 666,
@@ -34,7 +35,7 @@ describe('#Request', () => {
         error,
         connectionId: 'connectionId',
         protocol: 'protocol',
-        token: {token: 'token'},
+        token: { token: 'token' },
         user: { user: 'user' }
       },
       request = new Request({}, options);
@@ -48,13 +49,13 @@ describe('#Request', () => {
     should(request.error.status).be.exactly(request.error.status);
     should(request.context.protocol).eql('protocol');
     should(request.context.connectionId).eql('connectionId');
-    should(request.context.token).match({token: 'token'});
-    should(request.context.user).match({user: 'user'});
+    should(request.context.token).match({ token: 'token' });
+    should(request.context.user).match({ user: 'user' });
   });
 
   it('should instanciate a new KuzzleError object from a serialized error', () => {
     let
-      result = {foo: 'bar'},
+      result = { foo: 'bar' },
       error = new InternalError('foobar'),
       options = {
         status: 666,
@@ -62,7 +63,7 @@ describe('#Request', () => {
         error: error.toJSON(),
         connectionId: 'connectionId',
         protocol: 'protocol',
-        token: {token: 'token'},
+        token: { token: 'token' },
         user: { user: 'user' }
       },
       request = new Request({}, options);
@@ -75,8 +76,8 @@ describe('#Request', () => {
     should(request.error.status).be.exactly(request.error.status);
     should(request.context.protocol).eql('protocol');
     should(request.context.connectionId).eql('connectionId');
-    should(request.context.token).match({token: 'token'});
-    should(request.context.user).match({user: 'user'});
+    should(request.context.token).match({ token: 'token' });
+    should(request.context.user).match({ user: 'user' });
   });
 
   it('should throw if a non-object options argument is provided', () => {
@@ -86,10 +87,10 @@ describe('#Request', () => {
   });
 
   it('should throw if an invalid optional status is provided', () => {
-    should(function () { new Request({}, {status: []}); }).throw('Attribute status must be an integer');
-    should(function () { new Request({}, {status: {}}); }).throw('Attribute status must be an integer');
-    should(function () { new Request({}, {status: 'foobar'}); }).throw('Attribute status must be an integer');
-    should(function () { new Request({}, {status: 123.45}); }).throw('Attribute status must be an integer');
+    should(function () { new Request({}, { status: [] }); }).throw('Attribute status must be an integer');
+    should(function () { new Request({}, { status: {} }); }).throw('Attribute status must be an integer');
+    should(function () { new Request({}, { status: 'foobar' }); }).throw('Attribute status must be an integer');
+    should(function () { new Request({}, { status: 123.45 }); }).throw('Attribute status must be an integer');
   });
 
   it('should set an error properly', () => {
@@ -100,7 +101,7 @@ describe('#Request', () => {
     should(rq.error).be.exactly(foo);
     should(rq.status).eql(666);
 
-    should(rq.error.toJSON()).match({status: foo.status, message: foo.message});
+    should(rq.error.toJSON()).match({ status: foo.status, message: foo.message });
   });
 
   it('should wrap a plain Error object into an InternalError one', () => {
@@ -120,7 +121,7 @@ describe('#Request', () => {
   });
 
   it('should set the provided result with default status 200', () => {
-    let result = {foo: 'bar'};
+    let result = { foo: 'bar' };
     rq.setResult(result);
 
     should(rq.result).be.exactly(result);
@@ -128,8 +129,8 @@ describe('#Request', () => {
   });
 
   it('should set a custom status code if one is provided', () => {
-    let result = {foo: 'bar'};
-    rq.setResult(result, {status: 666});
+    let result = { foo: 'bar' };
+    rq.setResult(result, { status: 666 });
 
     should(rq.result).be.exactly(result);
     should(rq.status).eql(666);
@@ -140,26 +141,26 @@ describe('#Request', () => {
   });
 
   it('should throw if trying to set a non-integer status', () => {
-    should(function () { rq.setResult('foobar', {status: {}}); }).throw('Attribute status must be an integer');
-    should(function () { rq.setResult('foobar', {status: []}); }).throw('Attribute status must be an integer');
-    should(function () { rq.setResult('foobar', {status: true}); }).throw('Attribute status must be an integer');
-    should(function () { rq.setResult('foobar', {status: 123.45}); }).throw('Attribute status must be an integer');
+    should(function () { rq.setResult('foobar', { status: {} }); }).throw('Attribute status must be an integer');
+    should(function () { rq.setResult('foobar', { status: [] }); }).throw('Attribute status must be an integer');
+    should(function () { rq.setResult('foobar', { status: true }); }).throw('Attribute status must be an integer');
+    should(function () { rq.setResult('foobar', { status: 123.45 }); }).throw('Attribute status must be an integer');
   });
 
   it('should throw if trying to set some non-object headers', () => {
-    [ 42, [true, false], 'bar', true ].forEach(value => {
-      should(() => rq.setResult('foobar', {headers: value})).throw(
+    [42, [true, false], 'bar', true].forEach(value => {
+      should(() => rq.setResult('foobar', { headers: value })).throw(
         BadRequestError,
-        {message: 'Attribute headers must be of type "object"'});
+        { message: 'Attribute headers must be of type "object"' });
     });
   });
 
   it('should set the raw response indicator if provided', () => {
-    let result = {foo: 'bar'};
+    let result = { foo: 'bar' };
 
     should(rq.response.raw).be.false();
 
-    rq.setResult(result, {raw: true});
+    rq.setResult(result, { raw: true });
 
     should(rq.result).be.exactly(result);
     should(rq.response.raw).be.true();
@@ -167,7 +168,7 @@ describe('#Request', () => {
 
   it('should build a well-formed response', () => {
     const
-      result = {foo: 'bar'},
+      result = { foo: 'bar' },
       responseHeaders = {
         'X-Foo': 'bar',
         'X-Bar': 'baz'
@@ -185,7 +186,7 @@ describe('#Request', () => {
       },
       request = new Request(data);
 
-    request.setResult(result, {status: 201, headers: responseHeaders});
+    request.setResult(result, { status: 201, headers: responseHeaders });
     request.setError(error);
 
     const response = request.response;
@@ -204,10 +205,10 @@ describe('#Request', () => {
 
   it('should serialize the request correctly', () => {
     let
-      result = {foo: 'bar'},
+      result = { foo: 'bar' },
       error = new InternalError('foobar'),
       data = {
-        body: {some: 'body'},
+        body: { some: 'body' },
         timestamp: 'timestamp',
         index: 'idx',
         collection: 'collection',
@@ -227,7 +228,7 @@ describe('#Request', () => {
           url: 'url',
           foobar: 'barfoo',
           ips: ['i', 'p', 's'],
-          headers: {foo: 'args.headers'}
+          headers: { foo: 'args.headers' }
         }
       },
       request = new Request(data, options),
@@ -238,8 +239,8 @@ describe('#Request', () => {
 
     serialized = request.serialize();
 
-    should(serialized.data.body).match({some: 'body'});
-    should(serialized.data.volatile).match({some: 'meta'});
+    should(serialized.data.body).match({ some: 'body' });
+    should(serialized.data.volatile).match({ some: 'meta' });
     should(serialized.data.controller).be.eql('controller');
     should(serialized.data.action).be.eql('action');
     should(serialized.data.index).be.eql('idx');
@@ -254,7 +255,7 @@ describe('#Request', () => {
     should(serialized.options.result).match(result);
     should(serialized.options.status).be.eql(500);
 
-    should(serialized.headers).match({foo: 'args.headers'});
+    should(serialized.headers).match({ foo: 'args.headers' });
 
     const newRequest = new Request(serialized.data, serialized.options);
     should(newRequest.response.toJSON()).match(request.response.toJSON());
@@ -263,10 +264,10 @@ describe('#Request', () => {
 
   it('should clear the request error and status correctly', () => {
     const
-      result = {foo: 'bar'},
+      result = { foo: 'bar' },
       error = new InternalError('foobar'),
       data = {
-        body: {some: 'body'},
+        body: { some: 'body' },
         timestamp: 'timestamp',
         index: 'idx',
         collection: 'collection',
@@ -277,11 +278,11 @@ describe('#Request', () => {
           some: 'meta'
         },
         foo: 'bar',
-        headers: {foo: 'args.header'}
+        headers: { foo: 'args.header' }
       },
       request = new Request(data);
 
-    request.input.headers = {foo: 'input.header'};
+    request.input.headers = { foo: 'input.header' };
     request.setResult(result);
     request.setError(error);
 
@@ -291,5 +292,13 @@ describe('#Request', () => {
 
     should(request.error).be.eql(null);
     should(request.status).eql(200);
+  });
+
+  it('should add a deprecation correctly', () => {
+    rq.addDeprecation('1.0.0', 'You should now use Kuzzle v2');
+
+    should(rq.deprecations).be.Array();
+    should(rq.deprecations).be.lengthOf(1);
+    should(rq.deprecations[0]).deepEqual({ version: '1.0.0', message: 'You should now use Kuzzle v2' });
   });
 });


### PR DESCRIPTION
<!--
  This template is not mandatory.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do ?

* Adds a `addDeprecation(version, message)`
* Adds corresponding test
* Add corresponding docs

This PR can be use inside a Kuzzle controller to add a deprecation that will be sent via the request response allowing to display deprecation message from an SDK (among other)

### How should this be manually tested?

<!--
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->
  - Step 1 : clone the branch
  - Step 2 : start a Kuzzle server
  - Step 3 :  run 

```js
const { Request } = require('kuzzle-common-objects')
let request = new Request({});
request.addDeprecation('1.0.0', 'You should now use Kuzzle v2')
console.log(request.deprecations) // [{ version: '1.0.0', 'You should now use Kuzzle v2' }]
```

Linked issue: https://github.com/kuzzleio/kuzzle/issues/1661