### PR TITLE
Deprecate context.connection.misc.url

### DIFF
--- a/lib/models/requestContext.ts
+++ b/lib/models/requestContext.ts
@@ -77,8 +77,13 @@ interface IKuzzleConnection extends JSONObject {
   misc: {
     /**
      * HTTP url
+     * @deprecated use "path" instead
      */
     url?: string;
+    /**
+     * HTTP path
+     */
+    path?: string;
     /**
      * HTTP headers
      */


### PR DESCRIPTION
## What does this PR do ?

Since we use the `path` property to define HTTP routes in Kuzzle we should be consistent in the connection information.

Linked PR: https://github.com/kuzzleio/kuzzle/pull/1849